### PR TITLE
ioctls: reenable support of mshv

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -1,6 +1,16 @@
 {
   "tests": [
     {
+      "test_name": "build-mshv",
+      "command": "cargo build --release --no-default-features --features mshv",
+      "platform": ["x86_64"]
+    },
+    {
+      "test_name": "clippy-mshv",
+      "command": "cargo clippy --workspace --bins --examples --benches --no-default-features --features mshv --all-targets -- -D warnings",
+      "platform": ["x86_64"]
+    },
+    {
       "test_name": "build-nohv",
       "command": "cargo build --release --no-default-features",
       "platform": ["x86_64"]

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -15,7 +15,7 @@ features = ["kvm"]
 [features]
 default = ["kvm"]
 kvm = ["kvm-ioctls", "kvm-bindings"]
-#mshv = ["mshv-ioctls", "mshv-bindings"]
+mshv = ["mshv-ioctls", "mshv-bindings"]
 
 [dependencies]
 byteorder = ">=1.2.1"
@@ -27,5 +27,5 @@ thiserror = ">=1.0"
 vfio-bindings = "~0"
 vm-memory = { version = ">=0.6", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.8.0"
-#mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
-#mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }
+mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }


### PR DESCRIPTION
The vfio-ioctls v0.1.0 has been published, so reenable support of mshv.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>