### PR TITLE
Fix warnings and adjust test coverage

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 77.4,
+  "coverage_score": 77.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/crates/vfio-bindings/src/bindings_v5_0_0/mod.rs
+++ b/crates/vfio-bindings/src/bindings_v5_0_0/mod.rs
@@ -5,5 +5,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+// Keep this until https://github.com/rust-lang/rust-bindgen/issues/1651 is fixed.
+#![cfg_attr(test, allow(deref_nullptr))]
 
 pub mod vfio;


### PR DESCRIPTION
This PR includes the original one from dependabot https://github.com/rust-vmm/vfio/pull/5
It fixes clippy warnings and test coverage due to updated Rust version.