### PR TITLE
RFC: New APIs for vfio-ioctls

### DIFF
--- a/crates/vfio-ioctls/src/lib.rs
+++ b/crates/vfio-ioctls/src/lib.rs
@@ -66,7 +66,7 @@ mod vfio_device;
 mod vfio_ioctls;
 
 pub use vfio_device::{
-    VfioContainer, VfioDevice, VfioGroup, VfioIrq, VfioRegion, VfioRegionInfoCap,
+    VfioContainer, VfioDevice, VfioDeviceFd, VfioGroup, VfioIrq, VfioRegion, VfioRegionInfoCap,
     VfioRegionInfoCapNvlink2Lnkspd, VfioRegionInfoCapNvlink2Ssatgt, VfioRegionInfoCapSparseMmap,
     VfioRegionInfoCapType, VfioRegionSparseMmapArea,
 };
@@ -123,6 +123,10 @@ pub enum VfioError {
     VfioDeviceUnmaskIrq,
     #[error("failed to trigger vfio device irq")]
     VfioDeviceTriggerIrq,
+    #[error("failed to duplicate fd")]
+    VfioDeviceDupFd,
+    #[error("wrong device fd type")]
+    VfioDeviceFdWrongType,
 }
 
 /// Specialized version of `Result` for VFIO subsystem.

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -349,6 +349,53 @@ impl VfioContainer {
         })
     }
 
+    #[cfg(all(
+        any(feature = "kvm", all(feature = "mshv", target_arch = "x86_64")),
+        not(test)
+    ))]
+    fn device_set_group(&self, group: &VfioGroup, add: bool) -> Result<()> {
+        let group_fd_ptr = &group.as_raw_fd() as *const i32;
+
+        if let Some(device_fd) = self.device_fd.as_ref() {
+            match &device_fd.0 {
+                #[cfg(feature = "kvm")]
+                DeviceFdInner::Kvm(fd) => {
+                    let flag = if add {
+                        KVM_DEV_VFIO_GROUP_ADD
+                    } else {
+                        KVM_DEV_VFIO_GROUP_DEL
+                    };
+                    let dev_attr = kvm_device_attr {
+                        flags: 0,
+                        group: KVM_DEV_VFIO_GROUP,
+                        attr: u64::from(flag),
+                        addr: group_fd_ptr as u64,
+                    };
+                    fd.set_device_attr(&dev_attr)
+                        .map_err(VfioError::SetDeviceAttr)
+                }
+                #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+                DeviceFdInner::Mshv(fd) => {
+                    let flag = if add {
+                        MSHV_DEV_VFIO_GROUP_ADD
+                    } else {
+                        MSHV_DEV_VFIO_GROUP_DEL
+                    };
+                    let dev_attr = mshv_device_attr {
+                        flags: 0,
+                        group: MSHV_DEV_VFIO_GROUP,
+                        attr: u64::from(flag),
+                        addr: group_fd_ptr as u64,
+                    };
+                    fd.set_device_attr(&dev_attr)
+                        .map_err(VfioError::SetDeviceAttr)
+                }
+            }
+        } else {
+            Ok(())
+        }
+    }
+
     /// Add a device to a VFIO group
     ///
     /// The VFIO device fd should have been set.
@@ -360,36 +407,7 @@ impl VfioContainer {
         not(test)
     ))]
     fn device_add_group(&self, group: &VfioGroup) -> Result<()> {
-        let group_fd_ptr = &group.as_raw_fd() as *const i32;
-
-        if let Some(device_fd) = self.device_fd.as_ref() {
-            match &device_fd.0 {
-                #[cfg(feature = "kvm")]
-                DeviceFdInner::Kvm(fd) => {
-                    let dev_attr = kvm_device_attr {
-                        flags: 0,
-                        group: KVM_DEV_VFIO_GROUP,
-                        attr: u64::from(KVM_DEV_VFIO_GROUP_ADD),
-                        addr: group_fd_ptr as u64,
-                    };
-                    fd.set_device_attr(&dev_attr)
-                        .map_err(VfioError::SetDeviceAttr)
-                }
-                #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
-                DeviceFdInner::Mshv(fd) => {
-                    let dev_attr = mshv_device_attr {
-                        flags: 0,
-                        group: MSHV_DEV_VFIO_GROUP,
-                        attr: u64::from(MSHV_DEV_VFIO_GROUP_ADD),
-                        addr: group_fd_ptr as u64,
-                    };
-                    fd.set_device_attr(&dev_attr)
-                        .map_err(VfioError::SetDeviceAttr)
-                }
-            }
-        } else {
-            Ok(())
-        }
+        self.device_set_group(group, true)
     }
 
     /// Delete a device from a VFIO group
@@ -403,36 +421,7 @@ impl VfioContainer {
         not(test)
     ))]
     fn device_del_group(&self, group: &VfioGroup) -> Result<()> {
-        let group_fd_ptr = &group.as_raw_fd() as *const i32;
-
-        if let Some(device_fd) = self.device_fd.as_ref() {
-            match &device_fd.0 {
-                #[cfg(feature = "kvm")]
-                DeviceFdInner::Kvm(fd) => {
-                    let dev_attr = kvm_device_attr {
-                        flags: 0,
-                        group: KVM_DEV_VFIO_GROUP,
-                        attr: u64::from(KVM_DEV_VFIO_GROUP_DEL),
-                        addr: group_fd_ptr as u64,
-                    };
-                    fd.set_device_attr(&dev_attr)
-                        .map_err(VfioError::SetDeviceAttr)
-                }
-                #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
-                DeviceFdInner::Mshv(fd) => {
-                    let dev_attr = mshv_device_attr {
-                        flags: 0,
-                        group: MSHV_DEV_VFIO_GROUP,
-                        attr: u64::from(MSHV_DEV_VFIO_GROUP_DEL),
-                        addr: group_fd_ptr as u64,
-                    };
-                    fd.set_device_attr(&dev_attr)
-                        .map_err(VfioError::SetDeviceAttr)
-                }
-            }
-        } else {
-            Ok(())
-        }
+        self.device_set_group(group, false)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
### Summary of the PR

While trying to make Cloud Hypervisor work for KVM and MSHV at the same time, I realize that leaking dependent types is a bad idea. That requires library users to provide different code paths depending on the features.

This PR provides a vfio-ioctls wrapper type which can hold either a KVM DeviceFd or MSHV DeviceFd. Unfortunately these are breaking changes.

Since I'm making breaking changes anyway, I slip in an extra patch to make a DeviceFd optional. This makes this crate useful for people who wants VFIO but have no need for a VM.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
