### PR TITLE
vfio-ioctls: fix clippy::needless-late-init warnings

### DIFF
--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -983,14 +983,13 @@ impl VfioDevice {
     /// * `buf`: data destination and buf length is read size
     /// * `addr`: offset in the region
     pub fn region_read(&self, index: u32, buf: &mut [u8], addr: u64) {
-        let region: &VfioRegion;
-        match self.regions.get(index as usize) {
-            Some(v) => region = v,
+        let region: &VfioRegion = match self.regions.get(index as usize) {
+            Some(v) => v,
             None => {
                 warn!("region read with invalid index: {}", index);
                 return;
             }
-        }
+        };
 
         let size = buf.len() as u64;
         if size > region.size || addr + size > region.size {
@@ -1016,14 +1015,13 @@ impl VfioDevice {
     /// * `buf`: data src and buf length is write size
     /// * `addr`: offset in the region
     pub fn region_write(&self, index: u32, buf: &[u8], addr: u64) {
-        let stub: &VfioRegion;
-        match self.regions.get(index as usize) {
-            Some(v) => stub = v,
+        let stub: &VfioRegion = match self.regions.get(index as usize) {
+            Some(v) => v,
             None => {
                 warn!("region write with invalid index: {}", index);
                 return;
             }
-        }
+        };
 
         let size = buf.len() as u64;
         if size > stub.size


### PR DESCRIPTION
### Summary of the PR

Fixed two clippy warnings.

This patch is split out from my other PR which changed the APIs of this crate. This can be applied independently.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
