### PR TITLE
vfio_device: enable IommuDmaMap/IommuDmaUnmap to take SysError

### DIFF
--- a/crates/vfio-ioctls/src/lib.rs
+++ b/crates/vfio-ioctls/src/lib.rs
@@ -107,10 +107,10 @@ pub enum VfioError {
     VfioDeviceGetRegionInfo(#[source] SysError),
     #[error("invalid file path")]
     InvalidPath,
-    #[error("failed to add guest memory map into iommu table")]
-    IommuDmaMap,
-    #[error("failed to remove guest memory map from iommu table")]
-    IommuDmaUnmap,
+    #[error("failed to add guest memory map into iommu table: {0}")]
+    IommuDmaMap(#[source] SysError),
+    #[error("failed to remove guest memory map from iommu table: {0}")]
+    IommuDmaUnmap(#[source] SysError),
     #[error("failed to get vfio device irq info")]
     VfioDeviceGetIrqInfo,
     #[error("failed to set vfio device irq")]
@@ -127,6 +127,10 @@ pub enum VfioError {
     VfioDeviceDupFd,
     #[error("wrong device fd type")]
     VfioDeviceFdWrongType,
+    #[error("failed to get host address")]
+    GetHostAddress,
+    #[error("invalid dma unmap size")]
+    InvalidDmaUnmapSize,
 }
 
 /// Specialized version of `Result` for VFIO subsystem.

--- a/crates/vfio-ioctls/src/vfio_ioctls.rs
+++ b/crates/vfio-ioctls/src/vfio_ioctls.rs
@@ -89,7 +89,7 @@ pub(crate) mod vfio_syscall {
         // we check the return value
         let ret = unsafe { ioctl_with_ref(container, VFIO_IOMMU_MAP_DMA(), dma_map) };
         if ret != 0 {
-            Err(VfioError::IommuDmaMap)
+            Err(VfioError::IommuDmaMap(SysError::last()))
         } else {
             Ok(())
         }
@@ -103,7 +103,7 @@ pub(crate) mod vfio_syscall {
         // we check the return value
         let ret = unsafe { ioctl_with_ref(container, VFIO_IOMMU_UNMAP_DMA(), dma_map) };
         if ret != 0 {
-            Err(VfioError::IommuDmaUnmap)
+            Err(VfioError::IommuDmaUnmap(SysError::last()))
         } else {
             Ok(())
         }
@@ -273,7 +273,7 @@ pub(crate) mod vfio_syscall {
         if dma_map.iova == 0x1000 {
             Ok(())
         } else {
-            Err(VfioError::IommuDmaMap)
+            Err(VfioError::IommuDmaMap(SysError::last()))
         }
     }
 
@@ -282,9 +282,12 @@ pub(crate) mod vfio_syscall {
         dma_map: &mut vfio_iommu_type1_dma_unmap,
     ) -> Result<()> {
         if dma_map.iova == 0x1000 {
+            if dma_map.size == 0x2000 {
+                dma_map.size = 0x1000;
+            }
             Ok(())
         } else {
-            Err(VfioError::IommuDmaUnmap)
+            Err(VfioError::IommuDmaUnmap(SysError::last()))
         }
     }
 


### PR DESCRIPTION
Improving the error that is reported through IommuDmaMap and IommuDmaUnmap
by propagating the system error retrieved through SysError.
    
Also introducing new types of VfioError to provide more appropriate errors
to the caller.

Signed-off-by: xuejun-xj <jiyunxue@linux.alibaba.com>
Signed-off-by: jingshan <jingshan@linux.alibaba.com>

### Summary of the PR

This PR enables VfioError::IommuDmaMap/IommuDmaUnmap to take SysError after calling the ioctls. 

Issue: #12 