### PR TITLE
build: Use caret dependencies for Rust-VMM crates

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 77.7,
+  "coverage_score": 79.1,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/crates/vfio-bindings/Cargo.toml
+++ b/crates/vfio-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-bindings"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The Cloud Hypervisor Authors"]
 license = "Apache-2.0 OR BSD-3-Clause"
 description = "Rust FFI bindings to vfio generated using bindgen."
@@ -17,7 +17,7 @@ vfio-v5_0_0 = []
 fam-wrappers = ["vmm-sys-util"]
 
 [dependencies]
-vmm-sys-util = { version = ">=0.8.0", optional = true }
+vmm-sys-util = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
-byteorder = ">=1.2.1"
+byteorder = "1.2.1"

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-ioctls"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Cloud Hypervisor Authors", "Liu Jiang <gerry@linux.alibaba.com>"]
 license = "Apache-2.0 OR BSD-3-Clause"
 description = "Safe wrappers over VFIO ioctls"
@@ -18,14 +18,14 @@ kvm = ["kvm-ioctls", "kvm-bindings"]
 mshv = ["mshv-ioctls", "mshv-bindings"]
 
 [dependencies]
-byteorder = ">=1.2.1"
-libc = ">=0.2.39"
+byteorder = "1.2.1"
+libc = "0.2.39"
 log = "0.4"
-kvm-bindings = { version = "~0", optional = true }
-kvm-ioctls = { version = "~0", optional = true }
-thiserror = ">=1.0"
-vfio-bindings = "~0"
-vm-memory = { version = ">=0.6", features = ["backend-mmap"] }
-vmm-sys-util = ">=0.8.0"
+kvm-bindings = { version = "0.6.0", optional = true }
+kvm-ioctls = { version = "0.12.0", optional = true }
+thiserror = "1.0"
+vfio-bindings = { version = "0.4.0", path = "../vfio-bindings" }
+vm-memory = { version = "0.10.0", features = ["backend-mmap"] }
+vmm-sys-util = "0.11.0"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }


### PR DESCRIPTION
And also bump the crate versions as well as the dependency versions.

See: rust-vmm/community#136

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
