### PR TITLE
vfio-ioctls: support platform devices to use vfio framework

### DIFF
--- a/crates/vfio-ioctls/src/lib.rs
+++ b/crates/vfio-ioctls/src/lib.rs
@@ -95,14 +95,14 @@ pub enum VfioError {
     GroupSetContainer,
     #[error("failed to unset vfio container")]
     UnsetContainer,
-    #[error("failed to set container's IOMMU driver type as VfioType1V2")]
-    ContainerSetIOMMU,
-    #[error("failed to get vfio device fd")]
-    GroupGetDeviceFD,
+    #[error("failed to set container's IOMMU driver type as VfioType1V2: {0}")]
+    ContainerSetIOMMU(#[source] SysError),
+    #[error("failed to get vfio device fd: {0}")]
+    GroupGetDeviceFD(#[source] SysError),
     #[error("failed to set vfio device's attribute: {0}")]
     SetDeviceAttr(#[source] SysError),
-    #[error("failed to get vfio device's info or info doesn't match")]
-    VfioDeviceGetInfo,
+    #[error("failed to get vfio device's info or info doesn't match: {0}")]
+    VfioDeviceGetInfo(#[source] SysError),
     #[error("failed to get vfio device's region info: {0}")]
     VfioDeviceGetRegionInfo(#[source] SysError),
     #[error("invalid file path")]

--- a/crates/vfio-ioctls/src/lib.rs
+++ b/crates/vfio-ioctls/src/lib.rs
@@ -101,8 +101,12 @@ pub enum VfioError {
     GroupGetDeviceFD(#[source] SysError),
     #[error("failed to set vfio device's attribute: {0}")]
     SetDeviceAttr(#[source] SysError),
-    #[error("failed to get vfio device's info or info doesn't match: {0}")]
+    #[error("failed to get vfio device's info: {0}")]
     VfioDeviceGetInfo(#[source] SysError),
+    #[error("vfio PCI device info doesn't match")]
+    VfioDeviceGetInfoPCI,
+    #[error("unsupported vfio device type")]
+    VfioDeviceGetInfoOther,
     #[error("failed to get vfio device's region info: {0}")]
     VfioDeviceGetRegionInfo(#[source] SysError),
     #[error("invalid file path")]

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -18,7 +18,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use log::{debug, error, warn};
 use vfio_bindings::bindings::vfio::*;
 use vm_memory::{Address, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
-use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::{errno::Error as SysError, eventfd::EventFd};
 
 use crate::fam::vec_with_array_field;
 use crate::vfio_ioctls::*;
@@ -502,7 +502,7 @@ impl VfioGroup {
             || dev_info.num_regions < VFIO_PCI_CONFIG_REGION_INDEX + 1
             || dev_info.num_irqs < VFIO_PCI_MSIX_IRQ_INDEX + 1
         {
-            return Err(VfioError::VfioDeviceGetInfo);
+            return Err(VfioError::VfioDeviceGetInfo(SysError::last()));
         }
 
         Ok(VfioDeviceInfo::new(device, &dev_info))

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -1473,4 +1473,22 @@ mod tests {
 
         container.vfio_unmap_guest_memory(&mem1).unwrap();
     }
+
+    #[test]
+    fn test_get_device_type() {
+        let flags: u32 = VFIO_DEVICE_FLAGS_PCI;
+        assert_eq!(flags, VfioGroup::get_device_type(&flags));
+
+        let flags: u32 = VFIO_DEVICE_FLAGS_PLATFORM;
+        assert_eq!(flags, VfioGroup::get_device_type(&flags));
+
+        let flags: u32 = VFIO_DEVICE_FLAGS_AMBA;
+        assert_eq!(flags, VfioGroup::get_device_type(&flags));
+
+        let flags: u32 = VFIO_DEVICE_FLAGS_CCW;
+        assert_eq!(flags, VfioGroup::get_device_type(&flags));
+
+        let flags: u32 = VFIO_DEVICE_FLAGS_AP;
+        assert_eq!(flags, VfioGroup::get_device_type(&flags));
+    }
 }

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -18,7 +18,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use log::{debug, error, warn};
 use vfio_bindings::bindings::vfio::*;
 use vm_memory::{Address, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
-use vmm_sys_util::{errno::Error as SysError, eventfd::EventFd};
+use vmm_sys_util::eventfd::EventFd;
 
 use crate::fam::vec_with_array_field;
 use crate::vfio_ioctls::*;
@@ -520,11 +520,11 @@ impl VfioGroup {
                 if dev_info.num_regions < VFIO_PCI_CONFIG_REGION_INDEX + 1
                     || dev_info.num_irqs < VFIO_PCI_MSIX_IRQ_INDEX + 1
                 {
-                    return Err(VfioError::VfioDeviceGetInfo(SysError::last()));
+                    return Err(VfioError::VfioDeviceGetInfoPCI);
                 }
             }
             _ => {
-                return Err(VfioError::VfioDeviceGetInfo(SysError::last()));
+                return Err(VfioError::VfioDeviceGetInfoOther);
             }
         }
 

--- a/crates/vfio-ioctls/src/vfio_ioctls.rs
+++ b/crates/vfio-ioctls/src/vfio_ioctls.rs
@@ -75,7 +75,7 @@ pub(crate) mod vfio_syscall {
         // SAFETY: file is vfio container and make sure val is valid.
         let ret = unsafe { ioctl_with_val(container, VFIO_SET_IOMMU(), val.into()) };
         if ret < 0 {
-            Err(VfioError::ContainerSetIOMMU)
+            Err(VfioError::ContainerSetIOMMU(SysError::last()))
         } else {
             Ok(())
         }
@@ -126,7 +126,7 @@ pub(crate) mod vfio_syscall {
         // SAFETY: we are the owner of self and path_ptr which are valid value.
         let fd = unsafe { ioctl_with_ptr(group, VFIO_GROUP_GET_DEVICE_FD(), path.as_ptr()) };
         if fd < 0 {
-            Err(VfioError::GroupGetDeviceFD)
+            Err(VfioError::GroupGetDeviceFD(SysError::last()))
         } else {
             // SAFETY: fd is valid FD
             Ok(unsafe { File::from_raw_fd(fd) })
@@ -164,7 +164,7 @@ pub(crate) mod vfio_syscall {
         // and we verify the return value.
         let ret = unsafe { ioctl_with_mut_ref(file, VFIO_DEVICE_GET_INFO(), dev_info) };
         if ret < 0 {
-            Err(VfioError::VfioDeviceGetInfo)
+            Err(VfioError::VfioDeviceGetInfo(SysError::last()))
         } else {
             Ok(())
         }


### PR DESCRIPTION
### Summary of the PR

*The vfio-rs framewrok only supports PCI devices at present. This PR aims at adding support for platform devices.*
