### PR TITLE
Uses resamplefd to bypass userspace VMM INTx EOI handling

### DIFF
--- a/crates/vfio-ioctls/src/lib.rs
+++ b/crates/vfio-ioctls/src/lib.rs
@@ -123,6 +123,8 @@ pub enum VfioError {
     VfioDeviceUnmaskIrq,
     #[error("failed to trigger vfio device irq")]
     VfioDeviceTriggerIrq,
+    #[error("failed to set vfio device irq resample fd")]
+    VfioDeviceSetIrqResampleFd,
     #[error("failed to duplicate fd")]
     VfioDeviceDupFd,
     #[error("wrong device fd type")]


### PR DESCRIPTION
KVM uses resamplefd to enables level triggered interrupts to be posted and re-enabled from vfio with no userspace intervention.  Currently vfio-ioctl doesn't provide an interface for registering resamplefd, so vmm must guess the intx eoi by trapping the write/read_bar, and re-enable(unmask) the interrupt in write/read_bar. Here we introduce  a new interface set_irq_resample_fd()  to set resamplefd to vfio that allow vfio automatically unmask the interrupt in the kernel.
