### PR TITLE
vfio-ioctls: Bump dependency on kvm-ioctls

### DIFF
--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.2.1"
 libc = "0.2.39"
 log = "0.4"
 kvm-bindings = { version = "0.6.0", optional = true }
-kvm-ioctls = { version = "0.12.0", optional = true }
+kvm-ioctls = { version = "0.13.0", optional = true }
 thiserror = "1.0"
 vfio-bindings = { version = "0.4.0", path = "../vfio-bindings" }
 vm-memory = { version = "0.10.0", features = ["backend-mmap"] }


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>
