### PR TITLE
build: Bump vm-memory from 0.10.0 to 0.11.0

### DIFF
--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -25,7 +25,7 @@ kvm-bindings = { version = "0.6.0", optional = true }
 kvm-ioctls = { version = "0.13.0", optional = true }
 thiserror = "1.0"
 vfio-bindings = { version = "0.4.0", path = "../vfio-bindings" }
-vm-memory = { version = "0.10.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.11.0"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }


### PR DESCRIPTION
### Summary of the PR

This PR bumps `vm-memory` from 0.10.0 to 0.11.0 so that the consumers of the `vfio` crates (e.g. Cloud Hypervisor) can also bump to use latest `vm-memory` crate.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
