### PR TITLE
ioctls: Convert mshv_ioctls::Result's errno using into()

### DIFF
--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -388,7 +388,7 @@ impl VfioContainer {
                         addr: group_fd_ptr as u64,
                     };
                     fd.set_device_attr(&dev_attr)
-                        .map_err(VfioError::SetDeviceAttr)
+                        .map_err(|e| VfioError::SetDeviceAttr(e.into()))
                 }
             }
         } else {


### PR DESCRIPTION
This allows the new MshvError Result type to be returned from the mshv-ioctls crate and converted appropriately.

This is backwards-compatible with the old errno:Error Result type.

### Summary of the PR

See https://github.com/rust-vmm/mshv/pull/138 for further details.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
