### PR TITLE
Fix endianess for fd's

### DIFF
--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use byteorder::{ByteOrder, LittleEndian};
+use byteorder::{ByteOrder, NativeEndian};
 use log::{debug, error, warn};
 use vfio_bindings::bindings::vfio::*;
 use vm_memory::{Address, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
@@ -930,7 +930,7 @@ impl VfioDevice {
             for (index, event_fd) in event_fds.iter().enumerate() {
                 let fds_offset = index * mem::size_of::<u32>();
                 let fd = &mut fds[fds_offset..fds_offset + mem::size_of::<u32>()];
-                LittleEndian::write_u32(fd, event_fd.as_raw_fd() as u32);
+                NativeEndian::write_u32(fd, event_fd.as_raw_fd() as u32);
             }
         }
 
@@ -980,7 +980,7 @@ impl VfioDevice {
             for (index, event_fd) in event_rfds.iter().enumerate() {
                 let fds_offset = index * mem::size_of::<u32>();
                 let fd = &mut fds[fds_offset..fds_offset + mem::size_of::<u32>()];
-                LittleEndian::write_u32(fd, event_fd.as_raw_fd() as u32);
+                NativeEndian::write_u32(fd, event_fd.as_raw_fd() as u32);
             }
         }
 


### PR DESCRIPTION
Passing an fd from user-space to the kernel requires native endianess. Change LittleEndian to NativeEndian to also support big endian machines.

@epilys  I think commit 07fd7ef3a1c2 ("vfio/pci: Use endian neutral helpers") is only tangentially related and as the commit message states did not change the observed behavior. As I understand it, that commit is about MMIO via pread() from the device fd which keeps the endianess of the read unchanged. This makes sense since it keeps the observed data consistent between pread() from the device fd and mmap() of the same fd where a load is then MMIO which for PCI is always little endian. For the case I encountered, this is about passing an fd from user-space to the kernel which requires native endianess.