### PR TITLE
build: Bump kvm-bindings and kvm-ioctls

### DIFF
--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -21,8 +21,8 @@ mshv = ["mshv-ioctls", "mshv-bindings"]
 byteorder = "1.2.1"
 libc = "0.2.39"
 log = "0.4"
-kvm-bindings = { version = "0.9.0", optional = true }
-kvm-ioctls = { version = "0.18.0", optional = true }
+kvm-bindings = { version = "0.10.0", optional = true }
+kvm-ioctls = { version = "0.19.0", optional = true }
 thiserror = "1.0"
 vfio-bindings = { version = "0.4.0", path = "../vfio-bindings" }
 vm-memory = { version = "0.16.0", features = ["backend-mmap"] }


### PR DESCRIPTION
### Summary of the PR

- Update kvm-bindings from 0.9.0 to 0.10.0
- Update kvm-ioctls from 0.18.0 to 0.19.0

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
