### PR TITLE
vfio-ioctls: Fix clippy warning

### DIFF
--- a/crates/vfio-ioctls/src/fam.rs
+++ b/crates/vfio-ioctls/src/fam.rs
@@ -9,7 +9,7 @@ use std::mem::size_of;
 
 /// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
 fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
-    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
+    let rounded_size = size_in_bytes.div_ceil(size_of::<T>());
     let mut v = Vec::with_capacity(rounded_size);
     for _ in 0..rounded_size {
         v.push(T::default())


### PR DESCRIPTION
### Summary of the PR

error: manually reimplementing `div_ceil`
  --> crates/vfio-ioctls/src/fam.rs:12:24
   |
12 |     let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   help: consider using `.div_ceil()`: `size_in_bytes.div_ceil(size_of::<T>())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
   = note: `-D clippy::manual-div-ceil` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_div_ceil)]`

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
