### PR TITLE
vfio-ioctls: Bump mshv crates to latest version

### DIFF
--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -30,8 +30,8 @@ thiserror = "1.0"
 vfio-bindings = { version = "0.4.0", path = "../vfio-bindings" }
 vm-memory = { version = "0.16.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.12.1"
-mshv-bindings = { version = "0.3.2", features = [
+mshv-bindings = { version = "0.3.5", features = [
   "with-serde",
   "fam-wrappers",
 ], optional = true }
-mshv-ioctls = { version = "0.3.2", optional = true }
+mshv-ioctls = { version = "0.3.5", optional = true }


### PR DESCRIPTION
Update mshv crates to v0.3.4

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
