### PR TITLE
vfio-ioctls: bump MSHV crates to latest version

### DIFF
--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -30,8 +30,8 @@ thiserror = "1.0"
 vfio-bindings = { version = "0.4.0", path = "../vfio-bindings" }
 vm-memory = { version = "0.16.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.12.1"
-mshv-bindings = { version = "0.4.0", features = [
+mshv-bindings = { version = "0.5.0", features = [
   "with-serde",
   "fam-wrappers",
 ], optional = true }
-mshv-ioctls = { version = "0.4.0", optional = true }
+mshv-ioctls = { version = "0.5.0", optional = true }


### PR DESCRIPTION
### Summary of the PR

Pinning the MSHV crates to 0.5.0 version.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
