### PR TITLE
vfio-bindings: Avoid manual modifications to auto-generated code

### DIFF
--- a/vfio-bindings/CONTRIBUTING.md
+++ b/vfio-bindings/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
 ### Bindgen
 The bindings are currently generated using
-[bindgen](https://crates.io/crates/bindgen):
+[bindgen](https://crates.io/crates/bindgen) version 0.71.1:
 
 ```bash
-cargo install bindgen
+cargo install bindgen-cli --vers 0.71.1
 ```
 
 ### Linux Kernel
@@ -45,8 +45,8 @@ git checkout v5.2
 make headers_install INSTALL_HDR_PATH=v5_2_headers
 cd v5_2_headers
 bindgen include/linux/vfio.h -o vfio.rs \
-    --with-derive-default \
-    --with-derive-partialeq \
+    --impl-debug --with-derive-default  \
+    --with-derive-partialeq  --impl-partialeq \
     -- -Iinclude
 
 cd ~
@@ -54,21 +54,6 @@ cd ~
 # Step 5: Copy the generated files to the new version module.
 cp linux/v5_2_headers/vfio.rs vfio-bindings/src/bindings_v5_2_0
 ```
-
-Once this is done, you need some modifications to the generated vfio.rs.
-First change below line:
-```rust
-pub const VFIO_TYPE: u8 = 59u8;
-```
-to
-```rust
-pub const VFIO_TYPE: u32 = 59;
-```
-
-This is required due to that bindgen can not generate VFIO_TYPE correctly
-at this moment. You might also want to add the proper license header to
-the file.
-
 Finally add the new version module to `vfio-bindings/lib.rs`. If this version
 is newer than the others already present, make this version the default one by
 getting it imported when there isn't any other version specified as a feature:

--- a/vfio-bindings/src/bindings_v5_0_0/vfio.rs
+++ b/vfio-bindings/src/bindings_v5_0_0/vfio.rs
@@ -61,7 +61,7 @@ pub const VFIO_EEH: u32 = 5;
 pub const VFIO_TYPE1_NESTING_IOMMU: u32 = 6;
 pub const VFIO_SPAPR_TCE_v2_IOMMU: u32 = 7;
 pub const VFIO_NOIOMMU_IOMMU: u32 = 8;
-pub const VFIO_TYPE: u32 = 59;
+pub const VFIO_TYPE: u8 = 59u8;
 pub const VFIO_BASE: u32 = 100;
 pub const VFIO_GROUP_FLAGS_VIABLE: u32 = 1;
 pub const VFIO_GROUP_FLAGS_CONTAINER_SET: u32 = 2;
@@ -598,6 +598,11 @@ impl Default for vfio_device_gfx_plane_info__bindgen_ty_1 {
         }
     }
 }
+impl ::std::fmt::Debug for vfio_device_gfx_plane_info__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "vfio_device_gfx_plane_info__bindgen_ty_1 {{ union }}")
+    }
+}
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of vfio_device_gfx_plane_info"]
@@ -638,6 +643,11 @@ impl Default for vfio_device_gfx_plane_info {
             ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
         }
+    }
+}
+impl ::std::fmt::Debug for vfio_device_gfx_plane_info {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write ! (f , "vfio_device_gfx_plane_info {{ argsz: {:?}, flags: {:?}, drm_plane_type: {:?}, drm_format: {:?}, drm_format_mod: {:?}, width: {:?}, height: {:?}, stride: {:?}, size: {:?}, x_pos: {:?}, y_pos: {:?}, x_hot: {:?}, y_hot: {:?}, __bindgen_anon_1: {:?} }}" , self . argsz , self . flags , self . drm_plane_type , self . drm_format , self . drm_format_mod , self . width , self . height , self . stride , self . size , self . x_pos , self . y_pos , self . x_hot , self . y_hot , self . __bindgen_anon_1)
     }
 }
 #[doc = " VFIO_DEVICE_IOEVENTFD - _IOW(VFIO_TYPE, VFIO_BASE + 16,\n                              struct vfio_device_ioeventfd)\n\n Perform a write to the device at the specified device fd offset, with\n the specified data and width when the provided eventfd is triggered.\n vfio bus drivers may not support this for all regions, for all widths,\n or at all.  vfio-pci currently only enables support for BAR regions,\n excluding the MSI-X vector table.\n\n Return: 0 on success, -errno on failure."]
@@ -837,6 +847,11 @@ impl Default for vfio_eeh_pe_op__bindgen_ty_1 {
         }
     }
 }
+impl ::std::fmt::Debug for vfio_eeh_pe_op__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "vfio_eeh_pe_op__bindgen_ty_1 {{ union }}")
+    }
+}
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of vfio_eeh_pe_op"][::std::mem::size_of::<vfio_eeh_pe_op>() - 40usize];
@@ -854,6 +869,15 @@ impl Default for vfio_eeh_pe_op {
             ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
         }
+    }
+}
+impl ::std::fmt::Debug for vfio_eeh_pe_op {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "vfio_eeh_pe_op {{ argsz: {:?}, flags: {:?}, op: {:?}, __bindgen_anon_1: {:?} }}",
+            self.argsz, self.flags, self.op, self.__bindgen_anon_1
+        )
     }
 }
 #[doc = " VFIO_IOMMU_SPAPR_REGISTER_MEMORY - _IOW(VFIO_TYPE, VFIO_BASE + 17, struct vfio_iommu_spapr_register_memory)\n\n Registers user space memory where DMA is allowed. It pins\n user pages and does the locked memory accounting so\n subsequent VFIO_IOMMU_MAP_DMA/VFIO_IOMMU_UNMAP_DMA calls\n get faster."]

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -17,32 +17,36 @@ use vmm_sys_util::errno::Error as SysError;
 use crate::vfio_device::{vfio_region_info_with_cap, VfioDeviceInfo};
 use crate::{Result, VfioContainer, VfioDevice, VfioError, VfioGroup};
 
-ioctl_io_nr!(VFIO_GET_API_VERSION, VFIO_TYPE, VFIO_BASE);
-ioctl_io_nr!(VFIO_CHECK_EXTENSION, VFIO_TYPE, VFIO_BASE + 1);
-ioctl_io_nr!(VFIO_SET_IOMMU, VFIO_TYPE, VFIO_BASE + 2);
-ioctl_io_nr!(VFIO_GROUP_GET_STATUS, VFIO_TYPE, VFIO_BASE + 3);
-ioctl_io_nr!(VFIO_GROUP_SET_CONTAINER, VFIO_TYPE, VFIO_BASE + 4);
-ioctl_io_nr!(VFIO_GROUP_UNSET_CONTAINER, VFIO_TYPE, VFIO_BASE + 5);
-ioctl_io_nr!(VFIO_GROUP_GET_DEVICE_FD, VFIO_TYPE, VFIO_BASE + 6);
-ioctl_io_nr!(VFIO_DEVICE_GET_INFO, VFIO_TYPE, VFIO_BASE + 7);
-ioctl_io_nr!(VFIO_DEVICE_GET_REGION_INFO, VFIO_TYPE, VFIO_BASE + 8);
-ioctl_io_nr!(VFIO_DEVICE_GET_IRQ_INFO, VFIO_TYPE, VFIO_BASE + 9);
-ioctl_io_nr!(VFIO_DEVICE_SET_IRQS, VFIO_TYPE, VFIO_BASE + 10);
-ioctl_io_nr!(VFIO_DEVICE_RESET, VFIO_TYPE, VFIO_BASE + 11);
+ioctl_io_nr!(VFIO_GET_API_VERSION, VFIO_TYPE.into(), VFIO_BASE);
+ioctl_io_nr!(VFIO_CHECK_EXTENSION, VFIO_TYPE.into(), VFIO_BASE + 1);
+ioctl_io_nr!(VFIO_SET_IOMMU, VFIO_TYPE.into(), VFIO_BASE + 2);
+ioctl_io_nr!(VFIO_GROUP_GET_STATUS, VFIO_TYPE.into(), VFIO_BASE + 3);
+ioctl_io_nr!(VFIO_GROUP_SET_CONTAINER, VFIO_TYPE.into(), VFIO_BASE + 4);
+ioctl_io_nr!(VFIO_GROUP_UNSET_CONTAINER, VFIO_TYPE.into(), VFIO_BASE + 5);
+ioctl_io_nr!(VFIO_GROUP_GET_DEVICE_FD, VFIO_TYPE.into(), VFIO_BASE + 6);
+ioctl_io_nr!(VFIO_DEVICE_GET_INFO, VFIO_TYPE.into(), VFIO_BASE + 7);
+ioctl_io_nr!(VFIO_DEVICE_GET_REGION_INFO, VFIO_TYPE.into(), VFIO_BASE + 8);
+ioctl_io_nr!(VFIO_DEVICE_GET_IRQ_INFO, VFIO_TYPE.into(), VFIO_BASE + 9);
+ioctl_io_nr!(VFIO_DEVICE_SET_IRQS, VFIO_TYPE.into(), VFIO_BASE + 10);
+ioctl_io_nr!(VFIO_DEVICE_RESET, VFIO_TYPE.into(), VFIO_BASE + 11);
 ioctl_io_nr!(
     VFIO_DEVICE_GET_PCI_HOT_RESET_INFO,
-    VFIO_TYPE,
+    VFIO_TYPE.into(),
     VFIO_BASE + 12
 );
-ioctl_io_nr!(VFIO_DEVICE_PCI_HOT_RESET, VFIO_TYPE, VFIO_BASE + 13);
-ioctl_io_nr!(VFIO_DEVICE_QUERY_GFX_PLANE, VFIO_TYPE, VFIO_BASE + 14);
-ioctl_io_nr!(VFIO_DEVICE_GET_GFX_DMABUF, VFIO_TYPE, VFIO_BASE + 15);
-ioctl_io_nr!(VFIO_DEVICE_IOEVENTFD, VFIO_TYPE, VFIO_BASE + 16);
-ioctl_io_nr!(VFIO_IOMMU_GET_INFO, VFIO_TYPE, VFIO_BASE + 12);
-ioctl_io_nr!(VFIO_IOMMU_MAP_DMA, VFIO_TYPE, VFIO_BASE + 13);
-ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE, VFIO_BASE + 14);
-ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE, VFIO_BASE + 15);
-ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE, VFIO_BASE + 16);
+ioctl_io_nr!(VFIO_DEVICE_PCI_HOT_RESET, VFIO_TYPE.into(), VFIO_BASE + 13);
+ioctl_io_nr!(
+    VFIO_DEVICE_QUERY_GFX_PLANE,
+    VFIO_TYPE.into(),
+    VFIO_BASE + 14
+);
+ioctl_io_nr!(VFIO_DEVICE_GET_GFX_DMABUF, VFIO_TYPE.into(), VFIO_BASE + 15);
+ioctl_io_nr!(VFIO_DEVICE_IOEVENTFD, VFIO_TYPE.into(), VFIO_BASE + 16);
+ioctl_io_nr!(VFIO_IOMMU_GET_INFO, VFIO_TYPE.into(), VFIO_BASE + 12);
+ioctl_io_nr!(VFIO_IOMMU_MAP_DMA, VFIO_TYPE.into(), VFIO_BASE + 13);
+ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE.into(), VFIO_BASE + 14);
+ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE.into(), VFIO_BASE + 15);
+ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE.into(), VFIO_BASE + 16);
 
 #[cfg(not(test))]
 // Safety:


### PR DESCRIPTION
### Summary of the PR

Auto-generated bindings are not supposed to be modified manually. Instead, it is
less error prone to ensure type compatibility from the consumer of the bindings,
such as 'vfio-ioctls' crate.

This patch also takes the opportunity to improve the CONTRIBUTING.md:

* Clarify the version of `bindgen` being used;
* Enable `--impl-debug` and `--impl-partialeq` with bindgen;

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
