### PR TITLE
vfio-user: Update package name for vfio-user

### DIFF
--- a/vfio-user/Cargo.toml
+++ b/vfio-user/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vfio_user"
+name = "vfio-user"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"


### PR DESCRIPTION
### Summary of the PR

Currently package name is called vfio_user but to be consistent with other packages it should be vfio-user instead.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
