### PR TITLE
vfio-user: make flags more ergonomic

### DIFF
--- a/vfio-user/src/lib.rs
+++ b/vfio-user/src/lib.rs
@@ -102,14 +102,14 @@ fn default_migration_capabilities() -> MigrationCapabilities {
 }
 
 bitflags! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct DmaMapFlags: u32 {
-        const READ_ONLY = 1 << 0;
-        const WRITE_ONLY = 1 << 1;
-        const READ_WRITE = Self::READ_ONLY.bits() | Self::WRITE_ONLY.bits();
+        const READ = 1 << 0;
+        const WRITE = 1 << 1;
+        const READ_WRITE = Self::READ.bits() | Self::WRITE.bits();
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct DmaUnmapFlags: u32 {
         const GET_DIRTY_PAGE_INFO = 1 << 1;
         const UNMAP_ALL = 1 << 2;


### PR DESCRIPTION
### Summary of the PR

There are two issues with `DmaMapFlags`:

1. `READ_ONLY` being set doesn't mean that the mapping is read-only. This is confusing in code that uses these constants (same for `WRITE_ONLY`). An example where this is benefitial is here: https://github.com/cyberus-technology/usbvfiod/pull/32/files#diff-2326ce243eaabb2d4481f571233172b300dfd478963b294654089275e7f70be0R25

3. Due to some bitflags update the type doesn't derive standard traits anymore. Manually annotate those. An example for code that would be improved is here: https://github.com/cyberus-technology/usbvfiod/pull/32/files#diff-2326ce243eaabb2d4481f571233172b300dfd478963b294654089275e7f70be0R25 Previously we could use `match`. No we have to manually compare bits and also escape type safety with `.bits()` to allow copying values.

Fix both of these issues. While I was here, I also added the necessary traits to `DmaUnmapFlags`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
