### PR TITLE
vfio-user: Fix clippy warning `mismatched_lifetime_syntaxes`

### DIFF
--- a/vfio-user/examples/gpio/pci.rs
+++ b/vfio-user/examples/gpio/pci.rs
@@ -555,7 +555,7 @@ impl PciConfiguration {
 
     /// Returns an iterator of the currently configured base address registers.
     #[allow(dead_code)] // TODO(dverkamp): remove this once used
-    pub fn get_bars(&self) -> PciBarIter {
+    pub fn get_bars(&self) -> PciBarIter<'_> {
         PciBarIter {
             config: self,
             bar_num: 0,


### PR DESCRIPTION
### Summary of the PR

Fix clippy warning as Rust toolchain 1.89.0-beta.3 (b5e10d8c0 2025-07-02) suggested.

```console
Error:    --> vfio-user/examples/gpio/pci.rs:558:21
    |
558 |     pub fn get_bars(&self) -> PciBarIter {
    |                     ^^^^^     ---------- the lifetime gets resolved as `'_`
    |                     |
    |                     this lifetime flows to the output
    |
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
558 |     pub fn get_bars(&self) -> PciBarIter<'_> {
    |                                         ++++
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
