### PR TITLE
Fix multiple soundness issues

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 - [[128]](https://github.com/rust-vmm/vfio/pull/128) Support vm-memory 0.17
 
+- [[103]](https://github.com/rust-vmm/vfio/pull/103)  Functions that map
+  memory into the VFIO device are now marked as `unsafe`.  The caller
+  of these functions is responsible for enforcing various complex but
+  documented invariants to avoid undefined behavior.  This requirement
+  is also present in previous versions of the crate, but the function
+  was not marked unsafe and the invariants were not documented.
+
+  In the future a high-level safe API may be provided that avoids
+  these requirements at the cost of some flexibility.
+
+  Also, size parameters are now `usize` instead of `u64`, and
+  address parameters are `*mut u8` instead of `u64`.
+
 ## Added
 
 - [[127]](https://github.com/rust-vmm/vfio/pull/127) vfio-ioctls: Add support for vfio cdev and iommufd

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -99,12 +99,15 @@ pub(crate) mod vfio_syscall {
         }
     }
 
-    pub(crate) fn map_dma(
+    /// # Safety
+    ///
+    /// See [`VfioContainer::vfio_dma_map`]
+    pub(crate) unsafe fn map_dma(
         container: &VfioContainer,
         dma_map: &vfio_iommu_type1_dma_map,
     ) -> Result<()> {
-        // SAFETY: file is vfio container, dma_map is constructed by us, and
-        // we check the return value
+        // SAFETY: File is vfio container and the ioctl number is valid.  Other
+        // invariants are the caller's responsibility.
         let ret = unsafe { ioctl_with_ref(container, VFIO_IOMMU_MAP_DMA(), dma_map) };
         if ret != 0 {
             Err(VfioError::IommuDmaMap(SysError::last()))
@@ -338,7 +341,7 @@ pub(crate) mod vfio_syscall {
         Ok(())
     }
 
-    pub(crate) fn map_dma(
+    pub(crate) unsafe fn map_dma(
         _container: &VfioContainer,
         dma_map: &vfio_iommu_type1_dma_map,
     ) -> Result<()> {


### PR DESCRIPTION
### Summary of the PR

vfio_syscall::map_dma causes the kernel to make an arbitrary address
accessible for DMA by a device the guest typically controls.  This is
unsafe, as it can change memory that Rust assumes is immutable.

I found this through a [review of Cloud Hypervisor][1], where I saw a
safe function that took a host address cast to u64 as an argument and
accessed that address.  It turns out that this function was the source
of the unsoundness.

[1]: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7129

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
