### PR TITLE
Refactor for supporting multiple VFIO interfaces: both legacy mode and cdev mode using iommufd

### DIFF
--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -66,9 +66,9 @@ mod vfio_device;
 mod vfio_ioctls;
 
 pub use vfio_device::{
-    VfioContainer, VfioDevice, VfioDeviceFd, VfioGroup, VfioIrq, VfioRegion, VfioRegionInfoCap,
-    VfioRegionInfoCapNvlink2Lnkspd, VfioRegionInfoCapNvlink2Ssatgt, VfioRegionInfoCapSparseMmap,
-    VfioRegionInfoCapType, VfioRegionSparseMmapArea,
+    VfioContainer, VfioDevice, VfioDeviceFd, VfioGroup, VfioIrq, VfioOps, VfioRegion,
+    VfioRegionInfoCap, VfioRegionInfoCapNvlink2Lnkspd, VfioRegionInfoCapNvlink2Ssatgt,
+    VfioRegionInfoCapSparseMmap, VfioRegionInfoCapType, VfioRegionSparseMmapArea,
 };
 
 /// Error codes for VFIO operations.

--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -137,6 +137,8 @@ pub enum VfioError {
     GetHostAddress,
     #[error("invalid dma unmap size")]
     InvalidDmaUnmapSize,
+    #[error("failed to downcast VfioOps")]
+    DowncastVfioOps,
 }
 
 /// Specialized version of `Result` for VFIO subsystem.


### PR DESCRIPTION
# Summary of the PR

To support advanced hardware features, the vfio subsystem now supports multiple modes, e.g. the legacy vfio mode using container and groups, and the new vfio cdev mode (#92). 

The current design and implementation of `vfio-ioctls` crate only supports legacy mode. Here is a proposal to refactor its design to support both modes.

## Refactor internal data structure and APIs

* Adopt 'KVM_DEV_VFIO_FILE*' uAPIs to accept vfio device files from userspace using both mode;
* Introduce `struct VfioCommon` to hold common data structure used by both mode;
* Make `struct VfioDevice` and `struct VfioDeviceInfo` mode agnostic (decoupling specifics of vfio container and groups);

## Redefine public APIs (exposed to user-space)

The public APIs exposed to user-space (say VMM) now are defined via a public trait:

```
/// Trait to define common operations exposed to user-space drivers for
/// VFIO device wrappers that are either backed by a legacy VfioContainer or
/// a VFIO cdev device using iommufd.
pub trait VfioOps: Any + Send + Sync {
    /// Map a region of user space memory (e.g. guest memory) into an IO
    /// address space managed by IOMMU hardware to enable DMA for
    /// associated VFIO devices
    ///
    /// # Parameters
    /// * iova: IO virtual address to map the memory.
    /// * size: size of the memory region.
    /// * user_addr: user space address (e.g. host virtual address) for
    ///   the guest memory region to map.
    fn vfio_dma_map(&self, _iova: u64, _size: u64, _user_addr: u64) -> Result<()> {
        unimplemented!()
    }

    /// Unmap a region of user space memory (e.g. guest memory) from an IO
    /// address space managed by IOMMU hardware to disable DMA for
    /// associated VFIO devices
    ///
    /// # Parameters
    /// * iova: IO virtual address to unmap the memory.
    /// * size: size of the memory region.
    fn vfio_dma_unmap(&self, _iova: u64, _size: u64) -> Result<()> {
        unimplemented!()
    }

    /// Downcast to the underlying vfio wrapper type
    fn as_any(&self) -> &dyn Any {
        unimplemented!()
    }
}
```

## Adopt the new public APIs 

Each mode defines its own data structure as the vfio device wrapper, which uses different kernel uAPIs to realize the same public APIs.

For example, with legacy vfio mode, the data strcuture for vfio device wrapper (e.g. refactored `struct VfioContainer`) keeps using vfio container and groups while implementing `pub trait VfioOps` to provide common public APIs for user space.

```
pub struct VfioContainer {
    pub(crate) container: File,
    pub(crate) groups: Mutex<HashMap<u32, Arc<VfioGroup>>>,
    #[allow(dead_code)]
    common: VfioCommon,
}

impl VfioOps for VfioContainer {
    ...
}
```

## Dependencies

This PR requires upgrading vfio-bindings to use kernel v6.6.0 (#104).

# Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.