### PR TITLE
vfio-user: Fix beta clippy issues

### DIFF
--- a/vfio-user/examples/gpio/main.rs
+++ b/vfio-user/examples/gpio/main.rs
@@ -89,8 +89,8 @@ impl ServerBackend for TestBackend {
         if region == VFIO_PCI_CONFIG_REGION_INDEX {
             if len > 4 {
                 // For larger accesses require multiple of 4 and natural
-                assert!(len % 4 == 0);
-                assert!(offset % 4 == 0);
+                assert!(len.is_multiple_of(4));
+                assert!(offset.is_multiple_of(4));
                 let mut reg_idx = offset as usize / 4;
                 let mut data_offset = 0;
                 while data_offset < len {
@@ -115,7 +115,7 @@ impl ServerBackend for TestBackend {
         } else if region == VFIO_PCI_BAR2_REGION_INDEX && offset == 0 {
             info!("gpio value read: count = {}", self.count);
             self.count += 1;
-            if self.count.0 % 3 == 0 {
+            if self.count.0.is_multiple_of(3) {
                 data[0] = 1;
                 if let Some(irq) = &mut self.irq {
                     info!("Triggering interrupt for count = {}", self.count);

--- a/vfio-user/examples/gpio/pci.rs
+++ b/vfio-user/examples/gpio/pci.rs
@@ -403,7 +403,7 @@ impl PciConfiguration {
 
     /// Writes a 32bit dword to `offset`. `offset` must be 32bit aligned.
     fn write_dword(&mut self, offset: usize, value: u32) {
-        if offset % 4 != 0 {
+        if !offset.is_multiple_of(4) {
             warn!("bad PCI config dword write offset {offset}");
             return;
         }
@@ -494,7 +494,7 @@ impl PciConfiguration {
             return Err(Error::BarSizeInvalid(config.size));
         }
 
-        if config.addr % config.size != 0 {
+        if !config.addr.is_multiple_of(config.size) {
             return Err(Error::BarAlignmentInvalid(config.addr, config.size));
         }
 


### PR DESCRIPTION
Fixed the following issue with `$cargo clippy --fix`:

error: manual implementation of `.is_multiple_of()`
   --> vfio-user/examples/gpio/pci.rs:406:12
    |
406 |         if offset % 4 != 0 {
    |            ^^^^^^^^^^^^^^^ help: replace with: `!offset.is_multiple_of(4)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
    = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_multiple_of)]`

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
