### PR TITLE
vfio-ioctls: upgrade mshv-bindings and mshv-ioctls

### DIFF
--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -30,8 +30,8 @@ thiserror = { workspace = true }
 vfio-bindings = { version = "=0.5.0", path = "../vfio-bindings" }
 vm-memory = { version = "0.16.0", features = ["backend-mmap"] }
 vmm-sys-util = { workspace = true }
-mshv-bindings = { version = "0.5.0", features = [
+mshv-bindings = { version = "0.6.0", features = [
   "with-serde",
   "fam-wrappers",
 ], optional = true }
-mshv-ioctls = { version = "0.5.0", optional = true }
+mshv-ioctls = { version = "0.6.0", optional = true }


### PR DESCRIPTION
### Summary of the PR

New version of mshv-bindings & mshv-ioctls have been released.
Upgrade mshv-bindings and mshv-ioctls to 0.6.0.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
