### PR TITLE
Cargo.toml: Update deps to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ members = ["vfio-bindings", "vfio-ioctls", "vfio-user"]
 resolver = "2"
 
 [workspace.dependencies]
-thiserror = "2.0.12"
-vmm-sys-util = "0.14.0"
+thiserror = "2.0.16"
+vmm-sys-util = "0.15.0"

--- a/vfio-bindings/CHANGELOG.md
+++ b/vfio-bindings/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Upcoming Release
 
+## Changed
+
+- [[114]](https://github.com/rust-vmm/vfio/pull/114) Cargo.toml: Update deps to latest version
+
+## Fixed
+
+## Added
+
 # [v0.6.0]
 
 ## Changed

--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Upcoming release
 
+## Changed
+
+- [[114]](https://github.com/rust-vmm/vfio/pull/114)  Cargo.toml: Update deps to latest version
+
+## Added
+
+## Fixed
+
 # [v0.5.1]
 
 ### Changed

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -24,8 +24,8 @@ mshv = ["mshv-ioctls", "mshv-bindings"]
 byteorder = "1.2.1"
 libc = "0.2.39"
 log = "0.4"
-kvm-bindings = { version = "0.12.0", optional = true }
-kvm-ioctls = { version = "0.22.0", optional = true }
+kvm-bindings = { version = "0.14.0", optional = true }
+kvm-ioctls = { version = "0.24.0", optional = true }
 thiserror = { workspace = true }
 vfio-bindings = { version = "=0.6.0", path = "../vfio-bindings" }
 vm-memory = { version = "0.16.0", features = ["backend-mmap"] }

--- a/vfio-user/CHANGELOG.md
+++ b/vfio-user/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- [[114]](https://github.com/rust-vmm/vfio/pull/114) Cargo.toml: Update deps to latest version
 
 ### Deprecated
 

--- a/vfio-user/Cargo.toml
+++ b/vfio-user/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rust-vmm/vfio-user"
 name = "gpio"
 
 [dependencies]
-bitflags = "2.9.0"
+bitflags = "2.9.4"
 libc = "0.2.139"
 log = "0.4.17"
 serde = { version = "1.0.151", features = ["rc"] }


### PR DESCRIPTION
### Summary of the PR

thiserror -> 2.0.12 to 2.0.16
vmm-sys-util -> 0.14.0 to 0.15.0
kvm-bindings -> 0.12.0 to 0.14.0
kvm-ioctls -> 0.22.0 to 0.24.0
bitflags -> 2.9.0 to 2.9.4

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
