### PR TITLE
vfio-ioctls: Add function to get num of vfio group

### DIFF
--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -346,6 +346,15 @@ impl VfioContainer {
         })
     }
 
+    /// Get vfio group num in the container.
+    ///
+    /// The vfio kernel driver will unmap and unpin all of the guest memory
+    /// when group_list is empty, so it's useful to let the owner know how many
+    /// group left in our list to decide to do dma map again.
+    pub fn vfio_group_num(&self) -> usize {
+        self.groups.lock().unwrap().len()
+    }
+
     #[cfg(all(any(feature = "kvm", feature = "mshv"), not(test)))]
     fn device_set_group(&self, group: &VfioGroup, add: bool) -> Result<()> {
         let group_fd_ptr = &group.as_raw_fd() as *const i32;


### PR DESCRIPTION
The vfio kernel driver will unmap and unpin all guest memory when there are no vfio group in its list. Vmm must do dma map again when that happens, but they don't know how many vfio group we owned.

This patch add a function for the vmm to get num of vfio group, so it's convenient for them to decide whether to do dma map again.

More discussion can be seen in:
https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7328