### PR TITLE
vfio-ioctls: Update CHANGELOG

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Changed
 
 ## Added
+- [[106]](https://github.com/rust-vmm/vfio/pull/106) Added new public APIs
+	to support multiple VFIO interfaces: both legacy mode (using
+	containers and groups) and cdev mode (using iommufd)
 
 ## Fixed
 


### PR DESCRIPTION
This is to include changes from #106 regarding redefined new public APIs to support the new VFIO cdev mode. The kernel plans to depcreate the older "legacy mode" (using containers and groups) that the existing public APIs target.

To facilitate migration, the new APIs supports boths modes. Users of the vfio-ioctls crate are encouraged to adopt the new APIs first, before the legacy VFIO mode is deprecated in the future.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
