### PR TITLE
Support vm-memory 0.17

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changed
 
+- [[128]](https://github.com/rust-vmm/vfio/pull/128) Support vm-memory 0.17
+
 ## Added
 
 - [[127]](https://github.com/rust-vmm/vfio/pull/127) vfio-ioctls: Add support for vfio cdev and iommufd

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -29,7 +29,7 @@ kvm-bindings = { version = "0.14.0", optional = true }
 kvm-ioctls = { version = "0.24.0", optional = true }
 thiserror = { workspace = true }
 vfio-bindings = { version = "=0.6.1", path = "../vfio-bindings" }
-vm-memory = { version = "0.16.0", features = ["backend-mmap"] }
+vm-memory = { version = ">= 0.16.0, < 0.18", features = ["backend-mmap"] }
 vmm-sys-util = { workspace = true }
 mshv-bindings = { version = "0.6.5", features = [
   "with-serde",

--- a/vfio-user/CHANGELOG.md
+++ b/vfio-user/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changed
 
+- [[128]](https://github.com/rust-vmm/vfio/pull/128) Support vm-memory 0.17
+
 ## Added
 
 ## Fixed

--- a/vfio-user/Cargo.toml
+++ b/vfio-user/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = { workspace = true }
 vfio-bindings = { version = "=0.6.1", path = "../vfio-bindings", features = [
   "fam-wrappers",
 ] }
-vm-memory = { version = "0.16.0", features = [
+vm-memory = { version = ">= 0.16.0, < 0.18", features = [
   "backend-mmap",
   "backend-atomic",
 ] }


### PR DESCRIPTION
### Summary of the PR

0.18 is already out, but is not compatible with 0.16/0.17 from the perspective of the vfio crates.  Since 0.18 is not widely adopted yet, it would be nice to get a release supporting 0.17 out first, and then move on to switching to 0.18.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
