### PR TITLE
[RFC] Support hardware-accelerated nested translation via iommufd

### DIFF
--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -36,5 +36,5 @@ mshv-bindings = { version = "0.6.5", features = [
   "fam-wrappers",
 ], optional = true }
 mshv-ioctls = { version = "0.6.5", optional = true }
-iommufd-bindings = { git = "https://github.com/cloud-hypervisor/iommufd", rev = "083c016", optional = true }
-iommufd-ioctls = { git = "https://github.com/cloud-hypervisor/iommufd", rev = "083c016", optional = true }
+iommufd-bindings = { git = "https://github.com/likebreath/iommufd", branch = "0129/rfc_viommu_vdevice", optional = true }
+iommufd-ioctls = { git = "https://github.com/likebreath/iommufd", branch = "0129/rfc_viommu_vdevice", optional = true }

--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -167,6 +167,21 @@ pub enum VfioError {
     #[cfg(feature = "vfio_cdev")]
     #[error("failed iommufd ioctl")]
     IommufdIoctlError(#[source] IommufdError),
+    #[cfg(feature = "vfio_cdev")]
+    #[error("missing virt_sid for S1 HWPT setup")]
+    MissingVirtSid,
+    #[cfg(feature = "vfio_cdev")]
+    #[error("failed to create iommufd vIOMMU")]
+    NewIommufdVIommu(#[source] IommufdError),
+    #[cfg(feature = "vfio_cdev")]
+    #[error("failed to create iommufd vDevice")]
+    NewIommufdVDevice(#[source] IommufdError),
+    #[cfg(feature = "vfio_cdev")]
+    #[error("failed to destroy s1 hwpt")]
+    IommufdS1HwptDestroy(#[source] IommufdError),
+    #[cfg(feature = "vfio_cdev")]
+    #[error("failed to allocate s1 hwpt")]
+    IommufdS1HwptAlloc(#[source] IommufdError),
 }
 
 /// Specialized version of `Result` for VFIO subsystem.


### PR DESCRIPTION
### Motivation

Add infrastructure to enable VFIO devices to leverage hardware IOMMU acceleration through iommufd's uAPIs. This allows userspace VMMs to attach VFIO devices to hardware-accelerated virtual IOMMUs, particularly enabling userspace to configure stage-1 (guest-managed) page tables that are composed with stage-2 (host-managed) page tables in hardware.

This depends on the `IommufdVIOMMU` and `IommufdVDevice` abstractions introduced in the iommufd-ioctls crate [1].

### Architecture Overview
#### New Public Interfaces

1. `VfioIommufd::new()` extended with nested hwpt configuration:
   - Added `s1_hwpt_data_type: Option<iommu_hwpt_data_type>` parameter
   - Signature:
   ```rust
    pub fn new(
        iommufd: Arc<IommuFd>,
        ioas_id: Option<u32>,
        device_fd: Option<VfioContainerDeviceHandle>,
        s1_hwpt_data_type: Option<iommu_hwpt_data_type>,
    ) -> Result<Self> 
   ```
   - When `Some`, enables nested translation mode for subsequently attached VFIO devices
   - Supported types: `IOMMU_HWPT_DATA_ARM_SMMUV3`, `IOMMU_HWPT_DATA_VTD_S1`

2. `VfioDevice::new_with_iommufd()`:
   - New constructor for vfio devices backed by iommufd with hardware-accelerated nested HWPT support
   - Signature:
     ```rust
     pub fn new_with_iommufd(
         sysfspath: &Path,
         vfio_ops: Arc<dyn VfioOps>,
         viommu: &mut Option<Arc<IommufdVIommu>>,
         virt_sid: Option<u64>,
     ) -> Result<(Self, Option<IommufdVDevice>)>
     ```
   - Automatically creates IommufdVIommu/IommufdVDevice when nested mode is enabled via `VfioIommufd`
   - Supports sharing a single `IommufdVIommu` instance across multiple VFIO devices
   - Returns `IommufdVDevice` handle for subsequent S1 HWPT operations
   - Attaches device to bypass HWPT by default (until guest enables IOMMU)

3. `VfioDevice::install_s1_hwpt()`:
   - Install guest-configured stage-1 page tables into hardware
   - Signature:
     ```rust
     pub fn install_s1_hwpt(
         &self,
         vdevice: &mut IommufdVDevice,
         hwpt_data: &IommufdHwptData,
     ) -> Result<()>
     ```
   - Called when guest writes to virtual IOMMU stream table entries
   - Atomically replaces existing S1 HWPT if present
   - Uses `IommufdHwptData` enum for type-safe hardware-specific configuration

4. `VfioDevice::uninstall_s1_hwpt()`:
   - Revert device to bypass or abort mode
   - Signature:
     ```rust
     pub fn uninstall_s1_hwpt(
         &self,
         vdevice: &mut IommufdVDevice,
         abort: bool,
     ) -> Result<()>
     ```
   - abort=true: Use abort HWPT (fault all DMA)
   - abort=false: Use bypass HWPT (passthrough translation)
   - Called during guest IOMMU reset or shutdown

#### Dependencies on iommufd-ioctls:

This implementation builds upon three types from iommufd-ioctls [1]:

- `IommufdVIommu`: Represents a physical IOMMU slice managing S2 HWPT and default S1 HWPTs (bypass/abort). Shared across devices behind the same virtual IOMMU.

- `IommufdVDevice`: Represents a device attached to a `IommufdVIommu`. Handles dynamic S1 HWPT allocation and lifecycle management.

- `IommufdHwptData`: Type-safe enum for architecture-specific HWPT configuration (SMMUv3 STE data, VT-d context entries).

### Integration Notes for VMMs:

1. VMM creates `VfioIommufd` with `s1_hwpt_data_type` if hardware accelerated virtual IOMMUs are enabled and used to manage VFIO devices
2. VMM calls `VfioDevice::new_with_iommufd()` per passthrough device
   - The same instance of virtual IOMMU should reuse the same instance of `IommufdVIommu`
   - Each VFIO device will has its own `VfioDevice` and `IommufdVDevice` instance
3. VMM need to make sure the virtual IOMMU is compatible with the physical IOMMU:
   - `IommufdVDevice::get_hw_info` is used to retrieve hardware information of the physical IOMMU
3. VMM traps guest IOMMU commands and calls:
   - `install_s1_hwpt()` when guest enables IOMMU
   - `uninstall_s1_hwpt()` when guest disables IOMMU
   - `IommufdVIommu::invalidate_hwpt()` when guest invalidate IOTLB entries

This enables VMM to enable hardware-accelerated IOMMU to manage VFIO devices and use physical IOMMU hardware to directly process guest page tables.

[1] https://github.com/cloud-hypervisor/iommufd/pull/5
