### PR TITLE
build: Re-release v0.5.3 as 0.6.0

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Fixed
 
-# [v0.5.3]
+# [v0.6.0]
 
 ## Changed
 
@@ -35,6 +35,10 @@
 - [[127]](https://github.com/rust-vmm/vfio/pull/127) vfio-ioctls: Add support for vfio cdev and iommufd
 
 ## Fixed
+
+# [v0.5.3]
+
+Yanked due to semver breakage.
 
 # [v0.5.2]
 

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-ioctls"
-version = "0.5.3"
+version = "0.6.0"
 authors = [
   "The Cloud Hypervisor Authors",
   "Liu Jiang <gerry@linux.alibaba.com>",


### PR DESCRIPTION
### Summary of the PR

0.5.3 should have been 0.6.0 for semver reasons. That release will be
yanked and replaced with this one.

Fixes: #138

Signed-off-by: Rob Bradford <rbradford@meta.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
