### PR TITLE
vfio-ioctls: Add VFIO migration v2 ioctl wrappers

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 52.32,
+  "coverage_score": 55.96,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -6,6 +6,12 @@
 - [[148]](https://github.com/rust-vmm/vfio/pull/148) Add `VfioDevice::new_from_fd` to construct a `VfioDevice` from
   a pre-opened vfio device file (cdev mode only).
 
+- [[140]](https://github.com/rust-vmm/vfio/pull/140) Add VFIO migration v2 ioctl wrappers
+  on `VfioDevice` (`query_migration_support`, `set_migration_state`,
+  `get_migration_state`, `get_mig_data_size`, `mig_get_precopy_info`,
+  `read_migration_data`, `read_migration_data_to_end`, `write_migration_data`).
+  The migration data fd is held internally and not exposed to callers.
+
 ## Fixed
 
 # [v0.6.0]

--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -68,7 +68,7 @@ mod vfio_device;
 mod vfio_ioctls;
 
 pub use vfio_device::{
-    VfioContainer, VfioDevice, VfioDeviceFd, VfioGroup, VfioIrq, VfioOps, VfioRegion,
+    PrecopyInfo, VfioContainer, VfioDevice, VfioDeviceFd, VfioGroup, VfioIrq, VfioOps, VfioRegion,
     VfioRegionInfoCap, VfioRegionInfoCapNvlink2Lnkspd, VfioRegionInfoCapNvlink2Ssatgt,
     VfioRegionInfoCapSparseMmap, VfioRegionInfoCapType, VfioRegionSparseMmapArea,
 };
@@ -169,6 +169,12 @@ pub enum VfioError {
     IommufdIoctlError(#[source] IommufdError),
     #[error("failed to execute VFIO device feature ioctl: {0}")]
     VfioDeviceFeature(#[source] SysError),
+    #[error("failed to get migration precopy info: {0}")]
+    VfioMigGetPrecopyInfo(#[source] SysError),
+    #[error("VFIO migration data fd is not present")]
+    NoMigrationDataFd,
+    #[error("VFIO migration data I/O failed: {0}")]
+    VfioMigrationDataIo(#[source] io::Error),
 }
 
 /// Specialized version of `Result` for VFIO subsystem.

--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -167,6 +167,8 @@ pub enum VfioError {
     #[cfg(feature = "vfio_cdev")]
     #[error("failed iommufd ioctl")]
     IommufdIoctlError(#[source] IommufdError),
+    #[error("failed to execute VFIO device feature ioctl: {0}")]
+    VfioDeviceFeature(#[source] SysError),
 }
 
 /// Specialized version of `Result` for VFIO subsystem.

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1664,6 +1664,71 @@ impl VfioDevice {
 
         max_interrupts
     }
+
+    /// Query whether the device supports VFIO migration v2.
+    ///
+    /// Returns `Ok(Some(flags))` with the supported migration capabilities,
+    /// `Ok(None)` when the kernel or device does not support migration v2,
+    /// or `Err` on any other ioctl failure.
+    pub fn query_migration_support(&self) -> Result<Option<u64>> {
+        let mut feature_buf =
+            vec_with_array_field::<vfio_device_feature, vfio_device_feature_migration>(1);
+        feature_buf[0].argsz = (mem::size_of::<vfio_device_feature>()
+            + mem::size_of::<vfio_device_feature_migration>())
+            as u32;
+        feature_buf[0].flags = VFIO_DEVICE_FEATURE_GET | VFIO_DEVICE_FEATURE_MIGRATION;
+        match vfio_syscall::device_feature(self, &mut feature_buf[0]) {
+            Ok(()) => {
+                // SAFETY: vec_with_array_field reserved size_of::<vfio_device_feature_migration>()
+                // bytes immediately after the header, and the kernel populated `flags` on success.
+                let flags = unsafe {
+                    (*(feature_buf[0].data.as_ptr() as *const vfio_device_feature_migration)).flags
+                };
+                Ok(Some(flags))
+            }
+            // ENOTTY means the kernel is too old. EINVAL means the device
+            // does not support the feature.
+            Err(VfioError::VfioDeviceFeature(e))
+                if e.errno() == libc::ENOTTY || e.errno() == libc::EINVAL =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Get the current device migration state.
+    pub fn get_migration_state(&self) -> Result<u32> {
+        let mut feature_buf =
+            vec_with_array_field::<vfio_device_feature, vfio_device_feature_mig_state>(1);
+        feature_buf[0].argsz = (mem::size_of::<vfio_device_feature>()
+            + mem::size_of::<vfio_device_feature_mig_state>())
+            as u32;
+        feature_buf[0].flags = VFIO_DEVICE_FEATURE_GET | VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE;
+        vfio_syscall::device_feature(self, &mut feature_buf[0])?;
+        // SAFETY: vec_with_array_field reserved the payload bytes after the header.
+        let device_state = unsafe {
+            (*(feature_buf[0].data.as_ptr() as *const vfio_device_feature_mig_state)).device_state
+        };
+        Ok(device_state)
+    }
+
+    /// Query the maximum data size for a single stop-copy transfer.
+    pub fn get_mig_data_size(&self) -> Result<u64> {
+        let mut feature_buf =
+            vec_with_array_field::<vfio_device_feature, vfio_device_feature_mig_data_size>(1);
+        feature_buf[0].argsz = (mem::size_of::<vfio_device_feature>()
+            + mem::size_of::<vfio_device_feature_mig_data_size>())
+            as u32;
+        feature_buf[0].flags = VFIO_DEVICE_FEATURE_GET | VFIO_DEVICE_FEATURE_MIG_DATA_SIZE;
+        vfio_syscall::device_feature(self, &mut feature_buf[0])?;
+        // SAFETY: vec_with_array_field reserved the payload bytes after the header.
+        let stop_copy_length = unsafe {
+            (*(feature_buf[0].data.as_ptr() as *const vfio_device_feature_mig_data_size))
+                .stop_copy_length
+        };
+        Ok(stop_copy_length)
+    }
 }
 
 impl AsRawFd for VfioDevice {
@@ -1825,6 +1890,43 @@ mod tests {
             common: VfioCommon { device_fd: None },
             groups: Mutex::new(HashMap::new()),
         }
+    }
+
+    fn create_vfio_device() -> VfioDevice {
+        let tmp_file = TempFile::new().unwrap();
+        let path = tmp_file.as_path();
+        let device = File::open(path).unwrap();
+        let dev_info = vfio_syscall::create_dev_info_for_test();
+        let device_info = VfioDeviceInfo::new(device, &dev_info);
+        VfioDevice {
+            device: ManuallyDrop::new(File::open(path).unwrap()),
+            flags: 0,
+            regions: device_info.get_regions().unwrap(),
+            irqs: device_info.get_irqs().unwrap(),
+            sysfspath: Some(path.to_path_buf()),
+            vfio_ops: Arc::new(create_vfio_container()),
+        }
+    }
+
+    #[test]
+    fn test_query_migration_support() {
+        let device = create_vfio_device();
+        let result = device.query_migration_support().unwrap();
+        assert_eq!(result, Some(VFIO_MIGRATION_STOP_COPY as u64));
+    }
+
+    #[test]
+    fn test_get_migration_state() {
+        let device = create_vfio_device();
+        let state = device.get_migration_state().unwrap();
+        assert_eq!(state, vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING);
+    }
+
+    #[test]
+    fn test_get_mig_data_size() {
+        let device = create_vfio_device();
+        let size = device.get_mig_data_size().unwrap();
+        assert_eq!(size, 0x100000);
     }
 
     #[test]

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -8,8 +8,9 @@ use std::collections::HashMap;
 use std::convert::{TryFrom as _, TryInto as _};
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 use std::mem::{self, ManuallyDrop};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::prelude::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -39,8 +40,6 @@ use mshv_bindings::{
 };
 #[cfg(all(feature = "mshv", not(test)))]
 use mshv_ioctls::DeviceFd as MshvDeviceFd;
-#[cfg(all(any(feature = "kvm", feature = "mshv"), not(test)))]
-use std::os::unix::io::FromRawFd;
 #[cfg(all(any(feature = "kvm", feature = "mshv"), not(test)))]
 use vmm_sys_util::errno::Error;
 
@@ -1183,6 +1182,16 @@ pub struct VfioDevice {
     pub(crate) irqs: HashMap<u32, VfioIrq>,
     pub(crate) sysfspath: Option<PathBuf>,
     pub(crate) vfio_ops: Arc<dyn VfioOps>,
+    pub(crate) migration_data_fd: Mutex<Option<File>>,
+}
+
+/// Remaining migration data reported by the kernel during precopy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PrecopyInfo {
+    /// Bytes that must still be transferred to complete the initial state.
+    pub initial_bytes: u64,
+    /// Bytes of dirty state that have accumulated since precopy started.
+    pub dirty_bytes: u64,
 }
 
 impl VfioDevice {
@@ -1289,6 +1298,7 @@ impl VfioDevice {
             irqs,
             sysfspath: Some(sysfspath.to_path_buf()),
             vfio_ops,
+            migration_data_fd: Mutex::new(None),
         })
     }
 
@@ -1324,6 +1334,7 @@ impl VfioDevice {
             irqs,
             sysfspath: None,
             vfio_ops,
+            migration_data_fd: Mutex::new(None),
         })
     }
 
@@ -1697,6 +1708,54 @@ impl VfioDevice {
         }
     }
 
+    /// Set the device migration state.
+    ///
+    /// Transitions into a streaming state (PRE_COPY, PRE_COPY_P2P, STOP_COPY,
+    /// RESUMING) from a non-streaming state return a fresh data fd from the
+    /// kernel. The method stores it inside `VfioDevice` for the migration
+    /// data read and write helpers to use. Transitions between two streaming
+    /// states keep the existing fd. Transitions to a non-streaming state
+    /// drop any previously stored fd. On ioctl error the cached fd is also
+    /// dropped, since a partially completed state transition may already have
+    /// closed it on the kernel side.
+    pub fn set_migration_state(&self, state: u32) -> Result<()> {
+        let mut feature_buf =
+            vec_with_array_field::<vfio_device_feature, vfio_device_feature_mig_state>(1);
+        feature_buf[0].argsz = (mem::size_of::<vfio_device_feature>()
+            + mem::size_of::<vfio_device_feature_mig_state>())
+            as u32;
+        feature_buf[0].flags = VFIO_DEVICE_FEATURE_SET | VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE;
+        {
+            // SAFETY: vec_with_array_field reserved size_of::<vfio_device_feature_mig_state>()
+            // bytes immediately after the header.
+            let payload = unsafe {
+                &mut *(feature_buf[0].data.as_mut_ptr() as *mut vfio_device_feature_mig_state)
+            };
+            payload.device_state = state;
+            payload.data_fd = -1;
+        }
+        if let Err(e) = vfio_syscall::device_feature(self, &mut feature_buf[0]) {
+            *self.migration_data_fd.lock().unwrap() = None;
+            return Err(e);
+        }
+        // SAFETY: same buffer as above. The kernel may have written `data_fd`.
+        let data_fd = unsafe {
+            (*(feature_buf[0].data.as_ptr() as *const vfio_device_feature_mig_state)).data_fd
+        };
+        let is_streaming = state == vfio_device_mig_state_VFIO_DEVICE_STATE_PRE_COPY
+            || state == vfio_device_mig_state_VFIO_DEVICE_STATE_PRE_COPY_P2P
+            || state == vfio_device_mig_state_VFIO_DEVICE_STATE_STOP_COPY
+            || state == vfio_device_mig_state_VFIO_DEVICE_STATE_RESUMING;
+        let mut guard = self.migration_data_fd.lock().unwrap();
+        if data_fd >= 0 {
+            // SAFETY: data_fd is a valid file descriptor returned by the kernel.
+            *guard = Some(unsafe { File::from_raw_fd(data_fd) });
+        } else if !is_streaming {
+            *guard = None;
+        }
+        Ok(())
+    }
+
     /// Get the current device migration state.
     pub fn get_migration_state(&self) -> Result<u32> {
         let mut feature_buf =
@@ -1728,6 +1787,47 @@ impl VfioDevice {
                 .stop_copy_length
         };
         Ok(stop_copy_length)
+    }
+
+    /// Query remaining migration data on the stored precopy data fd.
+    pub fn mig_get_precopy_info(&self) -> Result<PrecopyInfo> {
+        let guard = self.migration_data_fd.lock().unwrap();
+        let fd = guard.as_ref().ok_or(VfioError::NoMigrationDataFd)?;
+        let mut info = vfio_precopy_info {
+            argsz: mem::size_of::<vfio_precopy_info>() as u32,
+            ..Default::default()
+        };
+        vfio_syscall::mig_get_precopy_info(fd, &mut info)?;
+        Ok(PrecopyInfo {
+            initial_bytes: info.initial_bytes,
+            dirty_bytes: info.dirty_bytes,
+        })
+    }
+
+    /// Read from the stored migration data fd into `buf`.
+    pub fn read_migration_data(&self, buf: &mut [u8]) -> Result<usize> {
+        let mut guard = self.migration_data_fd.lock().unwrap();
+        let fd = guard.as_mut().ok_or(VfioError::NoMigrationDataFd)?;
+        fd.read(buf).map_err(VfioError::VfioMigrationDataIo)
+    }
+
+    /// Drain the stored migration data fd until EOF.
+    pub fn read_migration_data_to_end(&self) -> Result<Vec<u8>> {
+        // Pre-size to avoid Vec reallocations during read_to_end.
+        let hint = self.get_mig_data_size().unwrap_or(0) as usize;
+        let mut guard = self.migration_data_fd.lock().unwrap();
+        let fd = guard.as_mut().ok_or(VfioError::NoMigrationDataFd)?;
+        let mut data = Vec::with_capacity(hint);
+        fd.read_to_end(&mut data)
+            .map_err(VfioError::VfioMigrationDataIo)?;
+        Ok(data)
+    }
+
+    /// Write the entire `data` slice to the stored migration data fd.
+    pub fn write_migration_data(&self, data: &[u8]) -> Result<()> {
+        let mut guard = self.migration_data_fd.lock().unwrap();
+        let fd = guard.as_mut().ok_or(VfioError::NoMigrationDataFd)?;
+        fd.write_all(data).map_err(VfioError::VfioMigrationDataIo)
     }
 }
 
@@ -1905,6 +2005,7 @@ mod tests {
             irqs: device_info.get_irqs().unwrap(),
             sysfspath: Some(path.to_path_buf()),
             vfio_ops: Arc::new(create_vfio_container()),
+            migration_data_fd: Mutex::new(None),
         }
     }
 
@@ -1913,6 +2014,50 @@ mod tests {
         let device = create_vfio_device();
         let result = device.query_migration_support().unwrap();
         assert_eq!(result, Some(VFIO_MIGRATION_STOP_COPY as u64));
+    }
+
+    #[test]
+    fn test_set_migration_state() {
+        let device = create_vfio_device();
+        device
+            .set_migration_state(vfio_device_mig_state_VFIO_DEVICE_STATE_STOP)
+            .unwrap();
+        assert!(device.migration_data_fd.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_set_migration_state_drops_fd_on_error() {
+        let device = create_vfio_device();
+        let tmp_file = TempFile::new().unwrap();
+        *device.migration_data_fd.lock().unwrap() = Some(File::open(tmp_file.as_path()).unwrap());
+
+        // u32::MAX is the test mock's sentinel for the ioctl failure path.
+        assert!(matches!(
+            device.set_migration_state(u32::MAX),
+            Err(VfioError::VfioDeviceFeature(_))
+        ));
+        assert!(device.migration_data_fd.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_set_migration_state_keeps_fd_across_streaming_transitions() {
+        // The test syscall always returns data_fd = -1 (no kernel-allocated fd
+        // in unit tests). Pre-populate the stored fd to simulate what the
+        // kernel would have handed us on a prior PRE_COPY entry, then issue a
+        // streaming-to-streaming transition and check the fd survives.
+        let device = create_vfio_device();
+        let tmp_file = TempFile::new().unwrap();
+        *device.migration_data_fd.lock().unwrap() = Some(File::open(tmp_file.as_path()).unwrap());
+
+        device
+            .set_migration_state(vfio_device_mig_state_VFIO_DEVICE_STATE_STOP_COPY)
+            .unwrap();
+        assert!(device.migration_data_fd.lock().unwrap().is_some());
+
+        device
+            .set_migration_state(vfio_device_mig_state_VFIO_DEVICE_STATE_STOP)
+            .unwrap();
+        assert!(device.migration_data_fd.lock().unwrap().is_none());
     }
 
     #[test]
@@ -1927,6 +2072,37 @@ mod tests {
         let device = create_vfio_device();
         let size = device.get_mig_data_size().unwrap();
         assert_eq!(size, 0x100000);
+    }
+
+    #[test]
+    fn test_mig_get_precopy_info_without_fd() {
+        let device = create_vfio_device();
+        assert!(matches!(
+            device.mig_get_precopy_info(),
+            Err(VfioError::NoMigrationDataFd)
+        ));
+    }
+
+    #[test]
+    fn test_mig_get_precopy_info_with_fd() {
+        let device = create_vfio_device();
+        let tmp_file = TempFile::new().unwrap();
+        *device.migration_data_fd.lock().unwrap() = Some(File::open(tmp_file.as_path()).unwrap());
+        let info = device.mig_get_precopy_info().unwrap();
+        assert_eq!(info, PrecopyInfo::default());
+    }
+
+    #[test]
+    fn test_migration_data_io_without_fd() {
+        let device = create_vfio_device();
+        assert!(matches!(
+            device.read_migration_data_to_end(),
+            Err(VfioError::NoMigrationDataFd)
+        ));
+        assert!(matches!(
+            device.write_migration_data(b""),
+            Err(VfioError::NoMigrationDataFd)
+        ));
     }
 
     #[test]

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -65,6 +65,7 @@ ioctl_io_nr!(VFIO_IOMMU_MAP_DMA, VFIO_TYPE.into(), VFIO_BASE + 13);
 ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE.into(), VFIO_BASE + 14);
 ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE.into(), VFIO_BASE + 15);
 ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE.into(), VFIO_BASE + 16);
+ioctl_io_nr!(VFIO_MIG_GET_PRECOPY_INFO, VFIO_TYPE.into(), VFIO_BASE + 21);
 
 #[cfg(not(test))]
 // Safety:
@@ -336,6 +337,17 @@ pub(crate) mod vfio_syscall {
         let ret = unsafe { ioctl_with_mut_ref(device, VFIO_DEVICE_FEATURE(), feature) };
         if ret < 0 {
             Err(VfioError::VfioDeviceFeature(SysError::last()))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn mig_get_precopy_info(fd: &File, info: &mut vfio_precopy_info) -> Result<()> {
+        // SAFETY: 'fd' is the migration data_fd returned by set_migration_state.
+        // 'info' is caller-allocated with `argsz` set.
+        let ret = unsafe { ioctl_with_mut_ref(fd, VFIO_MIG_GET_PRECOPY_INFO(), info) };
+        if ret < 0 {
+            Err(VfioError::VfioMigGetPrecopyInfo(SysError::last()))
         } else {
             Ok(())
         }
@@ -639,6 +651,9 @@ pub(crate) mod vfio_syscall {
                 let data = unsafe { &mut *(payload_ptr as *mut vfio_device_feature_mig_state) };
                 if feature.flags & VFIO_DEVICE_FEATURE_GET != 0 {
                     data.device_state = vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING;
+                } else if data.device_state == u32::MAX {
+                    // Sentinel used by unit tests to exercise the failure path.
+                    return Err(VfioError::VfioDeviceFeature(SysError::new(libc::EINVAL)));
                 }
                 data.data_fd = -1;
                 Ok(())
@@ -651,6 +666,12 @@ pub(crate) mod vfio_syscall {
             }
             _ => Err(VfioError::VfioDeviceFeature(SysError::new(libc::EINVAL))),
         }
+    }
+
+    pub(crate) fn mig_get_precopy_info(_fd: &File, info: &mut vfio_precopy_info) -> Result<()> {
+        info.initial_bytes = 0;
+        info.dirty_bytes = 0;
+        Ok(())
     }
 }
 
@@ -681,5 +702,6 @@ mod tests {
         #[cfg(feature = "vfio_cdev")]
         assert_eq!(VFIO_DEVICE_DETACH_IOMMUFD_PT(), 15224);
         assert_eq!(VFIO_DEVICE_FEATURE(), 15221);
+        assert_eq!(VFIO_MIG_GET_PRECOPY_INFO(), 15225);
     }
 }

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -45,6 +45,7 @@ ioctl_io_nr!(
 );
 ioctl_io_nr!(VFIO_DEVICE_GET_GFX_DMABUF, VFIO_TYPE.into(), VFIO_BASE + 15);
 ioctl_io_nr!(VFIO_DEVICE_IOEVENTFD, VFIO_TYPE.into(), VFIO_BASE + 16);
+ioctl_io_nr!(VFIO_DEVICE_FEATURE, VFIO_TYPE.into(), VFIO_BASE + 17);
 #[cfg(feature = "vfio_cdev")]
 ioctl_io_nr!(VFIO_DEVICE_BIND_IOMMUFD, VFIO_TYPE.into(), VFIO_BASE + 18);
 #[cfg(feature = "vfio_cdev")]
@@ -320,6 +321,21 @@ pub(crate) mod vfio_syscall {
             unsafe { ioctl_with_ref(vfio_cdev, VFIO_DEVICE_DETACH_IOMMUFD_PT(), detach_data) };
         if ret < 0 {
             Err(VfioError::VfioDeviceDetachIommufdPt(SysError::last()))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn device_feature(
+        device: &VfioDevice,
+        feature: &mut vfio_device_feature,
+    ) -> Result<()> {
+        // SAFETY: 'device' is a valid vfio device fd. The kernel reads
+        // `argsz` to bound access to the buffer, which the caller sized
+        // accordingly.
+        let ret = unsafe { ioctl_with_mut_ref(device, VFIO_DEVICE_FEATURE(), feature) };
+        if ret < 0 {
+            Err(VfioError::VfioDeviceFeature(SysError::last()))
         } else {
             Ok(())
         }
@@ -602,6 +618,40 @@ pub(crate) mod vfio_syscall {
     ) -> Result<()> {
         Ok(())
     }
+
+    pub(crate) fn device_feature(
+        _device: &VfioDevice,
+        feature: &mut vfio_device_feature,
+    ) -> Result<()> {
+        let feature_id = feature.flags & VFIO_DEVICE_FEATURE_MASK;
+        // The test caller sized the buffer with vec_with_array_field so
+        // the trailing payload follows the header.
+        let payload_ptr = feature.data.as_mut_ptr();
+        match feature_id {
+            VFIO_DEVICE_FEATURE_MIGRATION => {
+                // SAFETY: caller allocated space for vfio_device_feature_migration.
+                let data = unsafe { &mut *(payload_ptr as *mut vfio_device_feature_migration) };
+                data.flags = VFIO_MIGRATION_STOP_COPY as u64;
+                Ok(())
+            }
+            VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE => {
+                // SAFETY: caller allocated space for vfio_device_feature_mig_state.
+                let data = unsafe { &mut *(payload_ptr as *mut vfio_device_feature_mig_state) };
+                if feature.flags & VFIO_DEVICE_FEATURE_GET != 0 {
+                    data.device_state = vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING;
+                }
+                data.data_fd = -1;
+                Ok(())
+            }
+            VFIO_DEVICE_FEATURE_MIG_DATA_SIZE => {
+                // SAFETY: caller allocated space for vfio_device_feature_mig_data_size.
+                let data = unsafe { &mut *(payload_ptr as *mut vfio_device_feature_mig_data_size) };
+                data.stop_copy_length = 0x100000;
+                Ok(())
+            }
+            _ => Err(VfioError::VfioDeviceFeature(SysError::new(libc::EINVAL))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -630,5 +680,6 @@ mod tests {
         assert_eq!(VFIO_DEVICE_ATTACH_IOMMUFD_PT(), 15223);
         #[cfg(feature = "vfio_cdev")]
         assert_eq!(VFIO_DEVICE_DETACH_IOMMUFD_PT(), 15224);
+        assert_eq!(VFIO_DEVICE_FEATURE(), 15221);
     }
 }

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -11,6 +11,9 @@ use std::fs::File;
 use std::mem::size_of;
 use std::os::unix::io::AsRawFd;
 
+#[cfg(not(test))]
+use log::error;
+
 use vfio_bindings::bindings::vfio::*;
 use vmm_sys_util::errno::Error as SysError;
 
@@ -174,6 +177,10 @@ pub(crate) mod vfio_syscall {
         // SAFETY: we are the owner of self and container_raw_fd which are valid value.
         let ret = unsafe { ioctl_with_ref(group, VFIO_GROUP_UNSET_CONTAINER(), &container_raw_fd) };
         if ret < 0 {
+            error!(
+                "VFIO_GROUP_UNSET_CONTAINER ioctl failed: {}",
+                std::io::Error::last_os_error()
+            );
             Err(VfioError::GroupSetContainer)
         } else {
             Ok(())


### PR DESCRIPTION
### Summary of the PR
Add VFIO migration v2 ioctl wrappers to `VfioDevice` covering state transitions, data fd I/O, and precopy progress queries. Userspace can drive a VFIO device through the migration v2 state machine and stream save and restore data through the data fd  from the host kernel.

  ### Migration v2 methods to `VfioDevice`
  - `query_migration_support()`
  - `set_migration_state()`
  - `get_migration_state()`
  - `get_mig_data_size()`
  - `mig_get_precopy_info()`
  - `read_migration_data()`
  - `read_migration_data_to_end()`
  - `write_migration_data()`
  
`VfioDevice` holds the migration data fd internally to make the  public API safe to use. The fd is created on entry to PRE_COPY,  PRE_COPY_P2P, STOP_COPY or RESUMING, kept across  streaming-to-streaming arcs, and dropped when the device leaves  a streaming state. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
