### PR TITLE
vfio-user: Set type=Reply for error replies

### DIFF
--- a/vfio-user/src/lib.rs
+++ b/vfio-user/src/lib.rs
@@ -1359,7 +1359,7 @@ impl Server {
                 let reply = Header {
                     message_id: header.message_id,
                     command: header.command,
-                    flags: HeaderFlags::Error as u32,
+                    flags: HeaderFlags::Error as u32 | HeaderFlags::Reply as u32,
                     message_size: size_of::<Header>() as u32,
                     error: if matches!(e, Error::InvalidInput) {
                         EINVAL as u32


### PR DESCRIPTION
The vfio-user message header contains a Type field, which can be either Command (0) or Reply (1), as well as an Error flag. For error replies, both Type=1 and Error=1 should be set, but the vfio-user crate server implementation was only setting Error=1, leaving Type at its default value (0) and leading to misinterpretation by clients. Fix this by setting the type to Reply in addition to setting the Error bit.

Fixes: #143
