### PR TITLE
vfio-ioctls: Add VfioDevice::new_from_fd constructor

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Changed
 
 ## Added
+- [[148]](https://github.com/rust-vmm/vfio/pull/148) Add `VfioDevice::new_from_fd` to construct a `VfioDevice` from
+  a pre-opened vfio device file (cdev mode only).
 
 ## Fixed
 

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1222,6 +1222,33 @@ impl VfioDevice {
         }
     }
 
+    #[cfg(feature = "vfio_cdev")]
+    fn bind_device_to_iommufd(device: &File, vfio_iommufd: &VfioIommufd) -> Result<()> {
+        // Add the vfio cdev file to VFIO-KVM device tracking
+        vfio_iommufd
+            .common
+            .device_set_fd(device.as_raw_fd(), true)?;
+
+        // Bind the VFIO device to the iommufd file
+        let mut bind = vfio_device_bind_iommufd {
+            argsz: mem::size_of::<vfio_device_bind_iommufd>() as u32,
+            flags: 0,
+            iommufd: vfio_iommufd.iommufd.as_raw_fd(),
+            out_devid: 0,
+        };
+        vfio_syscall::bind_device_iommufd(device, &mut bind)?;
+
+        // Associate the vfio device to the IOAS within the bound iommufd
+        let mut attach_data = vfio_device_attach_iommufd_pt {
+            argsz: mem::size_of::<vfio_device_attach_iommufd_pt>() as u32,
+            flags: 0,
+            pt_id: vfio_iommufd.ioas_id,
+        };
+        vfio_syscall::attach_device_iommufd_pt(device, &mut attach_data)?;
+
+        Ok(())
+    }
+
     fn get_device_info(sysfspath: &Path, vfio_ops: Arc<dyn VfioOps>) -> Result<VfioDeviceInfo> {
         if let Some(vfio_container) = vfio_ops.as_any().downcast_ref::<VfioContainer>() {
             let group_id = Self::get_group_id_from_path(sysfspath)?;
@@ -1234,29 +1261,8 @@ impl VfioDevice {
         if let Some(vfio_iommufd) = vfio_ops.as_any().downcast_ref::<VfioIommufd>() {
             // Open the vfio cdev file
             let device = Self::get_device_cdev_from_path(sysfspath)?;
-
-            // Add the vfio cdev file to VFIO-KVM device tracking
-            vfio_iommufd
-                .common
-                .device_set_fd(device.as_raw_fd(), true)?;
-
-            // Bind the VFIO device to the iommufd file
-            let mut bind = vfio_device_bind_iommufd {
-                argsz: mem::size_of::<vfio_device_bind_iommufd>() as u32,
-                flags: 0,
-                iommufd: vfio_iommufd.iommufd.as_raw_fd(),
-                out_devid: 0,
-            };
-            vfio_syscall::bind_device_iommufd(&device, &mut bind)?;
-
-            // Associate the vfio device to the IOAS within the bound iommufd
-            let mut attach_data = vfio_device_attach_iommufd_pt {
-                argsz: mem::size_of::<vfio_device_attach_iommufd_pt>() as u32,
-                flags: 0,
-                pt_id: vfio_iommufd.ioas_id,
-            };
-            vfio_syscall::attach_device_iommufd_pt(&device, &mut attach_data)?;
-
+            // Bind the vfio cdev file to the iommufd
+            Self::bind_device_to_iommufd(&device, vfio_iommufd)?;
             let dev_info = VfioDeviceInfo::get_device_info(&device)?;
             let dev_info = VfioDeviceInfo::new(device, &dev_info);
 

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1181,7 +1181,7 @@ pub struct VfioDevice {
     pub(crate) flags: u32,
     pub(crate) regions: Vec<VfioRegion>,
     pub(crate) irqs: HashMap<u32, VfioIrq>,
-    pub(crate) sysfspath: PathBuf,
+    pub(crate) sysfspath: Option<PathBuf>,
     pub(crate) vfio_ops: Arc<dyn VfioOps>,
 }
 
@@ -1281,7 +1281,7 @@ impl VfioDevice {
             flags: device_info.flags,
             regions,
             irqs,
-            sysfspath: sysfspath.to_path_buf(),
+            sysfspath: Some(sysfspath.to_path_buf()),
             vfio_ops,
         })
     }
@@ -1642,7 +1642,13 @@ impl Drop for VfioDevice {
                 ManuallyDrop::drop(&mut self.device);
             }
 
-            let group_id = Self::get_group_id_from_path(&self.sysfspath).unwrap();
+            // VfioContainer always sets sysfspath, as it requires a sysfs path to get
+            // the group id and open the group file, so it is safe to unwrap here.
+            let sysfspath = self
+                .sysfspath
+                .as_deref()
+                .expect("VfioContainer requires a sysfs path");
+            let group_id = Self::get_group_id_from_path(sysfspath).unwrap();
             let group = container.get_group(group_id).unwrap();
             container.put_group(group);
         }

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1292,6 +1292,41 @@ impl VfioDevice {
         })
     }
 
+    /// Create a new vfio device from an already-opened vfio cdev file.
+    ///
+    /// This lets a caller pass in a pre-opened `/dev/vfio/devices/vfioN` FD
+    /// instead of discovering it through the sysfs path of a PCI device. It
+    /// is only valid when `vfio_ops` is a [`VfioIommufd`]: the legacy
+    /// container/group mode does not expose a per-device cdev, so there is
+    /// no equivalent FD to pass.
+    ///
+    /// # Parameters
+    /// * `device`: an opened vfio cdev file whose ownership is transferred
+    ///   into the returned `VfioDevice`.
+    /// * `vfio_ops`: must be a [`VfioIommufd`].
+    #[cfg(feature = "vfio_cdev")]
+    pub fn new_from_fd(device: File, vfio_ops: Arc<dyn VfioOps>) -> Result<Self> {
+        let vfio_iommufd = vfio_ops
+            .as_any()
+            .downcast_ref::<VfioIommufd>()
+            .ok_or(VfioError::DowncastVfioOps)?;
+        Self::bind_device_to_iommufd(&device, vfio_iommufd)?;
+
+        let dev_info = VfioDeviceInfo::get_device_info(&device)?;
+        let device_info = VfioDeviceInfo::new(device, &dev_info);
+        let regions = device_info.get_regions()?;
+        let irqs = device_info.get_irqs()?;
+
+        Ok(VfioDevice {
+            device: ManuallyDrop::new(device_info.device),
+            flags: device_info.flags,
+            regions,
+            irqs,
+            sysfspath: None,
+            vfio_ops,
+        })
+    }
+
     /// VFIO device reset only if the device supports being reset.
     pub fn reset(&self) {
         if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 {
@@ -2004,5 +2039,18 @@ mod tests {
 
         let flags: u32 = VFIO_DEVICE_FLAGS_AP;
         assert_eq!(flags, VfioDeviceInfo::get_device_type(&flags));
+    }
+
+    #[cfg(feature = "vfio_cdev")]
+    #[test]
+    fn test_vfio_device_new_from_fd_rejects_container() {
+        let tmp_file = TempFile::new().unwrap();
+        let device = File::open(tmp_file.as_path()).unwrap();
+        let container: Arc<dyn VfioOps> = Arc::new(create_vfio_container());
+
+        assert!(matches!(
+            VfioDevice::new_from_fd(device, container),
+            Err(VfioError::DowncastVfioOps)
+        ));
     }
 }


### PR DESCRIPTION
### Summary of the PR

Adds a new `VfioDevice::new_from_fd` API that constructs a `VfioDevice` from a pre-opened vfio cdev file, as an alternative to the existing sysfs-path-based construction.

This is useful for callers that already hold a /dev/vfio/devices/vfioN FD — for example received via FD passing from another process, or opened by a privileged helper — and do not need (or cannot access) the sysfs path of the underlying PCI device.

The new API is only valid with `VfioIommufd` (cdev mode). Legacy container/group mode has no per-device cdev equivalent, so an equivalent FD-based constructor is not meaningful there; passing non-iommufd vfio_ops returns `VfioError::DowncastVfioOps`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
