### PR TITLE
Bump Rust edition and replace trait object with generic

### DIFF
--- a/vfio-bindings/Cargo.toml
+++ b/vfio-bindings/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 description = "Rust FFI bindings to vfio generated using bindgen."
 repository = "https://github.com/rust-vmm/vfio"
 readme = "README.md"
-edition = "2018"
+edition = "2024"
 keywords = ["vfio"]
 
 [package.metadata.docs.rs]

--- a/vfio-bindings/src/vfio_bindings/vfio.rs
+++ b/vfio-bindings/src/vfio_bindings/vfio.rs
@@ -18,11 +18,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
@@ -658,7 +658,11 @@ impl Default for vfio_pci_dependent_device {
 }
 impl ::std::fmt::Debug for vfio_pci_dependent_device {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write ! (f , "vfio_pci_dependent_device {{ __bindgen_anon_1: {:?}, segment: {:?}, bus: {:?}, devfn: {:?} }}" , self . __bindgen_anon_1 , self . segment , self . bus , self . devfn)
+        write!(
+            f,
+            "vfio_pci_dependent_device {{ __bindgen_anon_1: {:?}, segment: {:?}, bus: {:?}, devfn: {:?} }}",
+            self.__bindgen_anon_1, self.segment, self.bus, self.devfn
+        )
     }
 }
 #[repr(C)]
@@ -814,7 +818,24 @@ impl Default for vfio_device_gfx_plane_info {
 }
 impl ::std::fmt::Debug for vfio_device_gfx_plane_info {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write ! (f , "vfio_device_gfx_plane_info {{ argsz: {:?}, flags: {:?}, drm_plane_type: {:?}, drm_format: {:?}, drm_format_mod: {:?}, width: {:?}, height: {:?}, stride: {:?}, size: {:?}, x_pos: {:?}, y_pos: {:?}, x_hot: {:?}, y_hot: {:?}, __bindgen_anon_1: {:?} }}" , self . argsz , self . flags , self . drm_plane_type , self . drm_format , self . drm_format_mod , self . width , self . height , self . stride , self . size , self . x_pos , self . y_pos , self . x_hot , self . y_hot , self . __bindgen_anon_1)
+        write!(
+            f,
+            "vfio_device_gfx_plane_info {{ argsz: {:?}, flags: {:?}, drm_plane_type: {:?}, drm_format: {:?}, drm_format_mod: {:?}, width: {:?}, height: {:?}, stride: {:?}, size: {:?}, x_pos: {:?}, y_pos: {:?}, x_hot: {:?}, y_hot: {:?}, __bindgen_anon_1: {:?} }}",
+            self.argsz,
+            self.flags,
+            self.drm_plane_type,
+            self.drm_format,
+            self.drm_format_mod,
+            self.width,
+            self.height,
+            self.stride,
+            self.size,
+            self.x_pos,
+            self.y_pos,
+            self.x_hot,
+            self.y_hot,
+            self.__bindgen_anon_1
+        )
     }
 }
 #[repr(C)]

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 description = "Safe wrappers over VFIO ioctls"
 repository = "https://github.com/rust-vmm/vfio"
 readme = "README.md"
-edition = "2018"
+edition = "2024"
 keywords = ["vfio"]
 
 [package.metadata.docs.rs]

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -30,13 +30,13 @@ use crate::vfio_ioctls::*;
 use crate::{Result, VfioError};
 #[cfg(all(feature = "kvm", not(test)))]
 use kvm_bindings::{
-    kvm_device_attr, KVM_DEV_VFIO_FILE, KVM_DEV_VFIO_FILE_ADD, KVM_DEV_VFIO_FILE_DEL,
+    KVM_DEV_VFIO_FILE, KVM_DEV_VFIO_FILE_ADD, KVM_DEV_VFIO_FILE_DEL, kvm_device_attr,
 };
 #[cfg(all(feature = "kvm", not(test)))]
 use kvm_ioctls::DeviceFd as KvmDeviceFd;
 #[cfg(all(feature = "mshv", not(test)))]
 use mshv_bindings::{
-    mshv_device_attr, MSHV_DEV_VFIO_FILE, MSHV_DEV_VFIO_FILE_ADD, MSHV_DEV_VFIO_FILE_DEL,
+    MSHV_DEV_VFIO_FILE, MSHV_DEV_VFIO_FILE_ADD, MSHV_DEV_VFIO_FILE_DEL, mshv_device_attr,
 };
 #[cfg(all(feature = "mshv", not(test)))]
 use mshv_ioctls::DeviceFd as MshvDeviceFd;
@@ -343,11 +343,11 @@ impl VfioContainer {
         vfio_syscall::set_group_container(&group, self)?;
 
         // Initialize the IOMMU backend driver after binding the first group object.
-        if hash.is_empty() {
-            if let Err(e) = self.set_iommu(VFIO_TYPE1v2_IOMMU) {
-                let _ = vfio_syscall::unset_group_container(&group, self);
-                return Err(e);
-            }
+        if hash.is_empty()
+            && let Err(e) = self.set_iommu(VFIO_TYPE1v2_IOMMU)
+        {
+            let _ = vfio_syscall::unset_group_container(&group, self);
+            return Err(e);
         }
 
         // Add the new group object to the hypervisor driver.
@@ -594,7 +594,7 @@ impl VfioOps for VfioContainer {
     /// concurrent read and write access to the memory via DMA.  Therefore, the
     /// memory may be read or written by the device at any time without synchronization.
     unsafe fn vfio_dma_map(&self, iova: u64, size: usize, user_addr: *mut u8) -> Result<()> {
-        self.vfio_dma_map(iova, size, user_addr)
+        unsafe { self.vfio_dma_map(iova, size, user_addr) }
     }
 
     /// Unmap a region of user space memory (e.g. guest memory) from an IO
@@ -1666,10 +1666,10 @@ impl VfioDevice {
         ];
 
         for index in irq_indexes {
-            if let Some(irq_info) = self.irqs.get(&index) {
-                if irq_info.count > max_interrupts {
-                    max_interrupts = irq_info.count;
-                }
+            if let Some(irq_info) = self.irqs.get(&index)
+                && irq_info.count > max_interrupts
+            {
+                max_interrupts = irq_info.count;
             }
         }
 

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -17,7 +17,7 @@ use log::error;
 use vfio_bindings::bindings::vfio::*;
 use vmm_sys_util::errno::Error as SysError;
 
-use crate::vfio_device::{vfio_region_info_with_cap, VfioDeviceInfo};
+use crate::vfio_device::{VfioDeviceInfo, vfio_region_info_with_cap};
 use crate::{Result, VfioContainer, VfioDevice, VfioError, VfioGroup};
 
 ioctl_io_nr!(VFIO_GET_API_VERSION, VFIO_TYPE.into(), VFIO_BASE);
@@ -357,7 +357,7 @@ pub(crate) mod vfio_syscall {
 #[cfg(test)]
 pub(crate) mod vfio_syscall {
     use super::*;
-    use vfio_bindings::bindings::vfio::{vfio_device_info, VFIO_IRQ_INFO_EVENTFD};
+    use vfio_bindings::bindings::vfio::{VFIO_IRQ_INFO_EVENTFD, vfio_device_info};
     use vmm_sys_util::tempfile::TempFile;
 
     pub(crate) fn check_api_version(_container: &VfioContainer) -> i32 {
@@ -492,7 +492,7 @@ pub(crate) mod vfio_syscall {
             idx if idx == VFIO_PCI_VGA_REGION_INDEX => {
                 return Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
                     libc::EINVAL,
-                )))
+                )));
             }
             idx if (2..VFIO_PCI_NUM_REGIONS).contains(&idx) => {
                 reg_info.flags = 0;
@@ -502,7 +502,7 @@ pub(crate) mod vfio_syscall {
             idx if idx == VFIO_PCI_NUM_REGIONS => {
                 return Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
                     libc::EINVAL,
-                )))
+                )));
             }
             _ => panic!("invalid device region index"),
         }
@@ -588,7 +588,7 @@ pub(crate) mod vfio_syscall {
             3 => {
                 return Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
                     libc::EINVAL,
-                )))
+                )));
             }
             _ => panic!("invalid device irq index"),
         }

--- a/vfio-user/Cargo.toml
+++ b/vfio-user/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vfio_user"
 version = "0.1.3"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Support for vfio-user devices"
 repository = "https://github.com/rust-vmm/vfio-user"
@@ -15,8 +15,7 @@ bitflags = "2.9.4"
 enumn = "0.1.14"
 libc = "0.2.139"
 log = "0.4.17"
-serde = { version = "1.0.151", features = ["rc"] }
-serde_derive = "1.0.149"
+serde = { version = "1.0.151", features = ["rc", "derive"] }
 serde_json = "1.0.93"
 thiserror = { workspace = true }
 vfio-bindings = { version = "=0.6.2", path = "../vfio-bindings", features = [

--- a/vfio-user/examples/gpio/main.rs
+++ b/vfio-user/examples/gpio/main.rs
@@ -8,10 +8,10 @@ use log::info;
 use pci::{PciBarConfiguration, PciSubclass};
 use std::{fs::File, io::Write, mem::size_of, num::Wrapping, path::PathBuf};
 use vfio_bindings::bindings::vfio::{
-    vfio_region_info, VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_SET_ACTION_TRIGGER,
-    VFIO_IRQ_SET_DATA_EVENTFD, VFIO_PCI_BAR2_REGION_INDEX, VFIO_PCI_CONFIG_REGION_INDEX,
-    VFIO_PCI_INTX_IRQ_INDEX, VFIO_PCI_NUM_IRQS, VFIO_PCI_NUM_REGIONS, VFIO_REGION_INFO_FLAG_READ,
-    VFIO_REGION_INFO_FLAG_WRITE,
+    VFIO_IRQ_INFO_EVENTFD, VFIO_IRQ_SET_ACTION_TRIGGER, VFIO_IRQ_SET_DATA_EVENTFD,
+    VFIO_PCI_BAR2_REGION_INDEX, VFIO_PCI_CONFIG_REGION_INDEX, VFIO_PCI_INTX_IRQ_INDEX,
+    VFIO_PCI_NUM_IRQS, VFIO_PCI_NUM_REGIONS, VFIO_REGION_INFO_FLAG_READ,
+    VFIO_REGION_INFO_FLAG_WRITE, vfio_region_info,
 };
 use vfio_user::{IrqInfo, Server, ServerBackend, ServerRegion};
 
@@ -150,7 +150,9 @@ impl ServerBackend for TestBackend {
         size: u64,
         fd: Option<File>,
     ) -> Result<(), std::io::Error> {
-        info!("dma_map flags = {flags:?} offset = {offset} address = {address} size = {size} fd = {fd:?}");
+        info!(
+            "dma_map flags = {flags:?} offset = {offset} address = {address} size = {size} fd = {fd:?}"
+        );
         Ok(())
     }
 
@@ -177,7 +179,9 @@ impl ServerBackend for TestBackend {
         count: u32,
         fds: Vec<File>,
     ) -> Result<(), std::io::Error> {
-        info!("set_irqs index = {index} flags = {flags} start = {start} count = {count} fds = {fds:?}");
+        info!(
+            "set_irqs index = {index} flags = {flags} start = {start} count = {count} fds = {fds:?}"
+        );
         if flags & (VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER) > 0 {
             if count == 1 {
                 self.irq = Some(fds[0].try_clone().unwrap());

--- a/vfio-user/examples/gpio/pci.rs
+++ b/vfio-user/examples/gpio/pci.rs
@@ -359,7 +359,7 @@ impl PciConfiguration {
             PciHeaderType::Bridge => {
                 registers[3] = 0x0001_0000; // Header type 1 (bridge)
                 writable_bits[6] = 0x00ff_ffff; // Primary/secondary/subordinate bus number,
-                                                // secondary latency timer
+                // secondary latency timer
                 registers[7] = 0x0000_00f0; // IO base > IO Limit, no IO address on secondary side at initialize
                 writable_bits[7] = 0xf900_0000; // IO base and limit, secondary status,
                 registers[8] = 0x0000_fff0; // mem base > mem Limit, no MMIO address on secondary side at initialize
@@ -566,8 +566,9 @@ impl PciConfiguration {
     pub fn get_bar_configuration(&self, bar_num: usize) -> Option<PciBarConfiguration> {
         let config = self.bar_configs.get(bar_num)?;
 
-        if let Some(mut config) = config {
+        if let Some(config) = config {
             let command = self.read_reg(COMMAND_REG);
+            let mut config = config.clone();
             if (config.is_memory() && (command & COMMAND_REG_MEMORY_SPACE_MASK == 0))
                 || (config.is_io() && (command & COMMAND_REG_IO_SPACE_MASK == 0))
             {

--- a/vfio-user/src/lib.rs
+++ b/vfio-user/src/lib.rs
@@ -4,8 +4,11 @@
 //
 
 use bitflags::bitflags;
-use libc::{c_void, iovec, EINVAL};
-use libc::{sysconf, _SC_PAGESIZE};
+use libc::{_SC_PAGESIZE, sysconf};
+use libc::{EINVAL, c_void, iovec};
+use log::*;
+use serde::Deserialize;
+use serde::Serialize;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::{IoSlice, Read, Write};
@@ -20,12 +23,6 @@ use thiserror::Error;
 use vfio_bindings::bindings::vfio::*;
 use vm_memory::{ByteValued, FileOffset};
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
-
-#[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
-extern crate log;
 
 #[allow(dead_code)]
 #[repr(u16)]
@@ -651,8 +648,10 @@ impl Client {
 
                     let area_num = sparse_mmap.nr_areas;
                     if cap_offset + mmap_cap_size + area_num * mmap_area_size > cap_size {
-                        warn!("Unexpected end of cap data: 'cap_offset + mmap_cap_size + area_num * mmap_area_size > cap_size' \
-                        cap_offset = {cap_offset}, mmap_cap_size = {mmap_area_size}, area_num = {area_num}, mmap_area_size = {mmap_area_size}, cap_size = {cap_size}");
+                        warn!(
+                            "Unexpected end of cap data: 'cap_offset + mmap_cap_size + area_num * mmap_area_size > cap_size' \
+                        cap_offset = {cap_offset}, mmap_cap_size = {mmap_area_size}, area_num = {area_num}, mmap_area_size = {mmap_area_size}, cap_size = {cap_size}"
+                        );
                         break;
                     }
                     let areas =
@@ -904,9 +903,9 @@ impl Server {
         })
     }
 
-    fn handle_command(
+    fn handle_command<B: ServerBackend>(
         &self,
-        backend: &mut dyn ServerBackend,
+        backend: &mut B,
         stream: &mut UnixStream,
         header: Header,
         fds: Vec<File>,
@@ -1372,7 +1371,7 @@ impl Server {
         Ok(())
     }
 
-    pub fn run(&self, backend: &mut dyn ServerBackend) -> Result<(), Error> {
+    pub fn run<B: ServerBackend>(&self, backend: &mut B) -> Result<(), Error> {
         let (mut stream, _) = self.listener.accept().map_err(Error::SocketAccept)?;
 
         loop {


### PR DESCRIPTION
### Summary of the PR

This is a non-functional change - bumped Rust edition, removed an unnecessary trait object and ran clippy over the code.