### PR TITLE
vfio-ioctls: Support pre-bound iommufd cdev fds

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -12,7 +12,7 @@
   `read_migration_data`, `read_migration_data_to_end`, `write_migration_data`).
   The migration data fd is held internally and not exposed to callers.
 
-- Add VFIO DMA dirty page logging methods on `VfioDevice`
+- [[150]](https://github.com/rust-vmm/vfio/pull/150) Add VFIO DMA dirty page logging methods on `VfioDevice`
   (`start_dma_logging`, `stop_dma_logging`, `report_dma_logging`) used by
   live migration to track guest pages dirtied by device DMA. Adds a
   public `DmaLoggingRange { iova, length }` struct. `start_dma_logging`
@@ -20,6 +20,9 @@
   `report_dma_logging`. Logging state is tracked per device so calling
   `start_dma_logging` twice, or `stop`/`report` without an active
   session, returns an error instead of issuing the ioctl.
+
+- [[153]](https://github.com/rust-vmm/vfio/pull/153) Add `VfioDevice::new_from_bound_fd` to construct a `VfioDevice`
+   from a pre-opened vfio device file that is already bound to an iommufd (cdev mode only).
 
 ## Fixed
 

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -37,4 +37,4 @@ mshv-bindings = { version = "0.6.5", features = [
 ], optional = true }
 mshv-ioctls = { version = "0.6.5", optional = true }
 iommufd-bindings = { version = "0.1.0", optional = true }
-iommufd-ioctls = { version = "0.1.0", optional = true }
+iommufd-ioctls = { version = "0.2.0", optional = true }

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -679,6 +679,8 @@ impl AsRawFd for VfioGroup {
 pub struct VfioIommufd {
     pub(crate) iommufd: Arc<IommuFd>,
     pub(crate) ioas_id: u32,
+    // True when we allocated the IOAS and must destroy it on drop
+    owns_ioas: bool,
     common: VfioCommon,
 }
 
@@ -696,6 +698,7 @@ impl VfioIommufd {
         ioas_id: Option<u32>,
         device_fd: Option<VfioContainerDeviceHandle>,
     ) -> Result<Self> {
+        let owns_ioas = ioas_id.is_none();
         let ioas_id = match ioas_id {
             Some(ioas_id) => ioas_id,
             None => {
@@ -717,6 +720,7 @@ impl VfioIommufd {
         let vfio_iommufd = VfioIommufd {
             iommufd,
             ioas_id,
+            owns_ioas,
             common: VfioCommon { device_fd },
         };
 
@@ -793,6 +797,27 @@ impl VfioIommufd {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "vfio_cdev")]
+impl Drop for VfioIommufd {
+    fn drop(&mut self) {
+        // Destroy the IOAS we allocated so a long-lived (externally
+        // supplied) iommufd does not accumulate orphan IOAS objects.
+        // By the time Drop runs, the `Arc<dyn VfioOps>` chain has
+        // already dropped every `VfioDevice`, each of which detached
+        // itself from this IOAS, so the kernel refcount is back to 1
+        // and IOMMU_DESTROY won't return -EBUSY. The destroy implicitly
+        // unmaps any remaining mappings too.
+        if self.owns_ioas {
+            if let Err(e) = self.iommufd.destroy_iommu_object(self.ioas_id) {
+                error!(
+                    "Failed to destroy IOAS {} on VfioIommufd drop: {}",
+                    self.ioas_id, e
+                );
+            }
+        }
     }
 }
 

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1369,6 +1369,50 @@ impl VfioDevice {
         })
     }
 
+    /// Construct a `VfioDevice` from a cdev file that is already
+    /// bound to `vfio_ops`'s iommufd.
+    ///
+    /// The cdev's bind state lives on the kernel `vfio_device_file`
+    /// and survives as long as the cdev struct file stays open.
+    /// This entry point skips bind step for use cases where the
+    /// caller already has a cdev file that is bound to the iommufd.
+    ///
+    /// # Parameters
+    /// * `device`: an opened, already-bound vfio cdev file whose
+    ///   ownership is transferred into the returned `VfioDevice`.
+    /// * `vfio_ops`: must be a [`VfioIommufd`] whose iommufd is the
+    ///   same one the cdev was previously bound against.
+    #[cfg(feature = "vfio_cdev")]
+    pub fn new_from_bound_fd(device: File, vfio_ops: Arc<dyn VfioOps>) -> Result<Self> {
+        let vfio_iommufd = vfio_ops
+            .as_any()
+            .downcast_ref::<VfioIommufd>()
+            .ok_or(VfioError::DowncastVfioOps)?;
+
+        // Add the vfio cdev file to VFIO-KVM device tracking
+        vfio_iommufd
+            .common
+            .device_set_fd(device.as_raw_fd(), true)?;
+        // Associate the vfio device to the IOAS within the bound iommufd
+        Self::attach_cdev_to_ioas(&device, vfio_iommufd)?;
+
+        let dev_info = VfioDeviceInfo::get_device_info(&device)?;
+        let device_info = VfioDeviceInfo::new(device, &dev_info);
+        let regions = device_info.get_regions()?;
+        let irqs = device_info.get_irqs()?;
+
+        Ok(VfioDevice {
+            device: ManuallyDrop::new(device_info.device),
+            flags: device_info.flags,
+            regions,
+            irqs,
+            sysfspath: None,
+            vfio_ops,
+            migration_data_fd: Mutex::new(None),
+            dma_logging_started: Mutex::new(false),
+        })
+    }
+
     /// VFIO device reset only if the device supports being reset.
     pub fn reset(&self) {
         if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 {
@@ -2699,6 +2743,19 @@ mod tests {
 
         assert!(matches!(
             VfioDevice::new_from_fd(device, container),
+            Err(VfioError::DowncastVfioOps)
+        ));
+    }
+
+    #[cfg(feature = "vfio_cdev")]
+    #[test]
+    fn test_vfio_device_new_from_bound_fd_rejects_container() {
+        let tmp_file = TempFile::new().unwrap();
+        let device = File::open(tmp_file.as_path()).unwrap();
+        let container: Arc<dyn VfioOps> = Arc::new(create_vfio_container());
+
+        assert!(matches!(
+            VfioDevice::new_from_bound_fd(device, container),
             Err(VfioError::DowncastVfioOps)
         ));
     }

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1241,14 +1241,12 @@ impl VfioDevice {
         }
     }
 
+    // Bind a cdev file to an iommufd.
+    // The binding persists until the cdev file is closed: the kernel tracks
+    // the binding on the cdev file and rejects any subsequent attempts
+    // (see `df->access_granted` in drivers/vfio/device_cdev.c).
     #[cfg(feature = "vfio_cdev")]
-    fn bind_device_to_iommufd(device: &File, vfio_iommufd: &VfioIommufd) -> Result<()> {
-        // Add the vfio cdev file to VFIO-KVM device tracking
-        vfio_iommufd
-            .common
-            .device_set_fd(device.as_raw_fd(), true)?;
-
-        // Bind the VFIO device to the iommufd file
+    fn bind_cdev_to_iommufd(device: &File, vfio_iommufd: &VfioIommufd) -> Result<()> {
         let mut bind = vfio_device_bind_iommufd {
             argsz: mem::size_of::<vfio_device_bind_iommufd>() as u32,
             flags: 0,
@@ -1257,7 +1255,12 @@ impl VfioDevice {
         };
         vfio_syscall::bind_device_iommufd(device, &mut bind)?;
 
-        // Associate the vfio device to the IOAS within the bound iommufd
+        Ok(())
+    }
+
+    // Attach a cdev to the iommufd's IOAS
+    #[cfg(feature = "vfio_cdev")]
+    fn attach_cdev_to_ioas(device: &File, vfio_iommufd: &VfioIommufd) -> Result<()> {
         let mut attach_data = vfio_device_attach_iommufd_pt {
             argsz: mem::size_of::<vfio_device_attach_iommufd_pt>() as u32,
             flags: 0,
@@ -1280,8 +1283,16 @@ impl VfioDevice {
         if let Some(vfio_iommufd) = vfio_ops.as_any().downcast_ref::<VfioIommufd>() {
             // Open the vfio cdev file
             let device = Self::get_device_cdev_from_path(sysfspath)?;
-            // Bind the vfio cdev file to the iommufd
-            Self::bind_device_to_iommufd(&device, vfio_iommufd)?;
+
+            // Add the vfio cdev file to VFIO-KVM device tracking
+            vfio_iommufd
+                .common
+                .device_set_fd(device.as_raw_fd(), true)?;
+            // Bind the VFIO device to the iommufd file
+            Self::bind_cdev_to_iommufd(&device, vfio_iommufd)?;
+            // Associate the vfio device to the IOAS within the bound iommufd
+            Self::attach_cdev_to_ioas(&device, vfio_iommufd)?;
+
             let dev_info = VfioDeviceInfo::get_device_info(&device)?;
             let dev_info = VfioDeviceInfo::new(device, &dev_info);
 
@@ -1331,7 +1342,15 @@ impl VfioDevice {
             .as_any()
             .downcast_ref::<VfioIommufd>()
             .ok_or(VfioError::DowncastVfioOps)?;
-        Self::bind_device_to_iommufd(&device, vfio_iommufd)?;
+
+        // Add the vfio cdev file to VFIO-KVM device tracking
+        vfio_iommufd
+            .common
+            .device_set_fd(device.as_raw_fd(), true)?;
+        // Bind the VFIO device to the iommufd file
+        Self::bind_cdev_to_iommufd(&device, vfio_iommufd)?;
+        // Associate the vfio device to the IOAS within the bound iommufd
+        Self::attach_cdev_to_ioas(&device, vfio_iommufd)?;
 
         let dev_info = VfioDeviceInfo::get_device_info(&device)?;
         let device_info = VfioDeviceInfo::new(device, &dev_info);


### PR DESCRIPTION
### Summary of the PR

Adds `VfioDevice::new_from_bound_fd` for callers that own the iommufd
lifecycle and pass in a cdev file that is already bound to an iommufd.
Useful when the bind state must outlive the `VfioDevice`.

Commits:
- `vfio-ioctls: Split bind/attach helpers for cdev mode` — refactor
  cdev setup so bind and attach can be invoked independently.
- `vfio-ioctls: Bump to iommufd-ioctls v0.2.0` — pick up APIs needed
  for the pre-bound path.
- `vfio-ioctls: Add VfioDevice::new_from_bound_fd` — new constructor
  that takes an already-bound cdev fd plus the caller's iommufd and
  IOAS, and only does the attach step.
- `vfio-ioctls: Destroy owned IOAS on VfioIommufd drop` — only the
  owning `VfioIommufd` destroys the IOAS; externally provided ones
  are left to the caller.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
