### PR TITLE
build: Bump kvm-ioctls dependency & release

### DIFF
--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## Fixed
 
+# [v0.7.0]
+
+## Changed
+
+- Bump `kvm-ioctls` dependency to 0.25.0
+
 # [v0.6.1]
 
 ## Changed

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.2.1"
 libc = "0.2.39"
 log = "0.4"
 kvm-bindings = { version = "0.14.0", optional = true }
-kvm-ioctls = { version = "0.24.0", optional = true }
+kvm-ioctls = { version = "0.25.0", optional = true }
 thiserror = { workspace = true }
 vfio-bindings = { version = "=0.6.2", path = "../vfio-bindings" }
 vm-memory = { version = ">= 0.16.0, < 0.18", features = ["backend-mmap"] }

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfio-ioctls"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
   "The Cloud Hypervisor Authors",
   "Liu Jiang <gerry@linux.alibaba.com>",


### PR DESCRIPTION
- **build: Bump kvm-ioctls dependency to 0.25.0**
- **vfio-ioctls: Release 0.7.0**

### Summary of the PR

Bump kvm-ioctls dependency and release.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
