### PR TITLE
vfio-user: Enable server creation with filedescriptor

### DIFF
--- a/vfio-user/CHANGELOG.md
+++ b/vfio-user/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Added
 
+- [[160]](https://github.com/rust-vmm/vfio/pull/160) construct vfio-user server from owned fd
+
 ## Fixed
 
 # [v0.1.3]

--- a/vfio-user/src/lib.rs
+++ b/vfio-user/src/lib.rs
@@ -11,6 +11,7 @@ use std::fs::File;
 use std::io::{IoSlice, Read, Write};
 use std::mem::size_of;
 use std::num::Wrapping;
+use std::os::fd::OwnedFd;
 use std::os::unix::{
     io::{FromRawFd, RawFd},
     net::{UnixListener, UnixStream},
@@ -876,7 +877,7 @@ pub struct ServerRegion {
 
 pub struct Server {
     listener: UnixListener,
-    path: PathBuf,
+    path: Option<PathBuf>,
     resettable: bool,
     irqs: Vec<IrqInfo>,
     regions: Vec<ServerRegion>,
@@ -897,11 +898,28 @@ impl Server {
 
         Ok(Server {
             listener,
-            path: path.to_path_buf(),
+            path: Some(path.to_path_buf()),
             resettable,
             irqs,
             regions,
         })
+    }
+
+    pub fn from_owned_fd(
+        fd: OwnedFd,
+        resettable: bool,
+        irqs: Vec<IrqInfo>,
+        regions: Vec<ServerRegion>,
+    ) -> Server {
+        let listener = UnixListener::from(fd);
+
+        Server {
+            listener,
+            path: None,
+            resettable,
+            irqs,
+            regions,
+        }
     }
 
     fn handle_command(
@@ -1431,8 +1449,10 @@ impl Server {
 
 impl Drop for Server {
     fn drop(&mut self) {
-        if self.path.exists() {
-            let _ = std::fs::remove_file(&self.path);
+        if let Some(path) = &self.path {
+            if path.exists() {
+                let _ = std::fs::remove_file(path);
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary of the PR

According to the specification the usage of fd's instead of only with a socket path should be possible.
This PR adds a new method to construct a vfio-user `Server` from a given `OwnedFd`. To do this the path field in Server is changed to an `Option`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.

fixes: #158