### PR TITLE
vfio-user: Address clippy issues

### DIFF
--- a/vfio-user/src/lib.rs
+++ b/vfio-user/src/lib.rs
@@ -363,7 +363,7 @@ impl Client {
 
         debug!(
             "Sent client version information: major = {} minor = {} capabilities = {:?}",
-            version.major, version.minor, &caps.capabilities
+            version.major, version.minor, caps.capabilities
         );
 
         self.next_message_id += Wrapping(1);
@@ -387,7 +387,7 @@ impl Client {
 
         debug!(
             "Received server version information: major = {} minor = {} capabilities = {:?}",
-            server_version.major, server_version.minor, &server_caps.capabilities
+            server_version.major, server_version.minor, server_caps.capabilities
         );
 
         Ok(())


### PR DESCRIPTION
 error: redundant reference in `debug!` argument
    --> vfio-user/src/lib.rs:366:43
     |
 366 |             version.major, version.minor, &caps.capabilities
     |                                           ^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `caps.capabilities`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#useless_borrows_in_formatting
     = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
