### PR TITLE
Add PASID attach and detach support for iommufd

### DIFF
--- a/vfio-bindings/CHANGELOG.md
+++ b/vfio-bindings/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Changed
 
+- [[167]](https://github.com/rust-vmm/vfio/pull/167) Extend the iommufd attach and detach structs with the pasid
+  field and the PASID flags from Linux v6.15
+
 ## Fixed
 
 ## Added

--- a/vfio-bindings/src/vfio_bindings/vfio.rs
+++ b/vfio-bindings/src/vfio_bindings/vfio.rs
@@ -883,17 +883,19 @@ const _: () = {
     ["Offset of field: vfio_device_bind_iommufd::out_devid"]
         [::std::mem::offset_of!(vfio_device_bind_iommufd, out_devid) - 12usize];
 };
+pub const VFIO_DEVICE_ATTACH_PASID: u32 = 1;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct vfio_device_attach_iommufd_pt {
     pub argsz: __u32,
     pub flags: __u32,
     pub pt_id: __u32,
+    pub pasid: __u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of vfio_device_attach_iommufd_pt"]
-        [::std::mem::size_of::<vfio_device_attach_iommufd_pt>() - 12usize];
+        [::std::mem::size_of::<vfio_device_attach_iommufd_pt>() - 16usize];
     ["Alignment of vfio_device_attach_iommufd_pt"]
         [::std::mem::align_of::<vfio_device_attach_iommufd_pt>() - 4usize];
     ["Offset of field: vfio_device_attach_iommufd_pt::argsz"]
@@ -902,23 +904,29 @@ const _: () = {
         [::std::mem::offset_of!(vfio_device_attach_iommufd_pt, flags) - 4usize];
     ["Offset of field: vfio_device_attach_iommufd_pt::pt_id"]
         [::std::mem::offset_of!(vfio_device_attach_iommufd_pt, pt_id) - 8usize];
+    ["Offset of field: vfio_device_attach_iommufd_pt::pasid"]
+        [::std::mem::offset_of!(vfio_device_attach_iommufd_pt, pasid) - 12usize];
 };
+pub const VFIO_DEVICE_DETACH_PASID: u32 = 1;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct vfio_device_detach_iommufd_pt {
     pub argsz: __u32,
     pub flags: __u32,
+    pub pasid: __u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of vfio_device_detach_iommufd_pt"]
-        [::std::mem::size_of::<vfio_device_detach_iommufd_pt>() - 8usize];
+        [::std::mem::size_of::<vfio_device_detach_iommufd_pt>() - 12usize];
     ["Alignment of vfio_device_detach_iommufd_pt"]
         [::std::mem::align_of::<vfio_device_detach_iommufd_pt>() - 4usize];
     ["Offset of field: vfio_device_detach_iommufd_pt::argsz"]
         [::std::mem::offset_of!(vfio_device_detach_iommufd_pt, argsz) - 0usize];
     ["Offset of field: vfio_device_detach_iommufd_pt::flags"]
         [::std::mem::offset_of!(vfio_device_detach_iommufd_pt, flags) - 4usize];
+    ["Offset of field: vfio_device_detach_iommufd_pt::pasid"]
+        [::std::mem::offset_of!(vfio_device_detach_iommufd_pt, pasid) - 8usize];
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]

--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Added
 
+- [[167]](https://github.com/rust-vmm/vfio/pull/167) Add `attach_iommufd_pt_pasid` and `detach_iommufd_pt_pasid` to
+  `VfioDevice` for the PASID variants of the iommufd attach and detach
+  ioctls
+
 ## Fixed
 
 # [v0.7.0]

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1290,6 +1290,7 @@ impl VfioDevice {
             argsz: mem::size_of::<vfio_device_attach_iommufd_pt>() as u32,
             flags: 0,
             pt_id: vfio_iommufd.ioas_id,
+            pasid: 0,
         };
         vfio_syscall::attach_device_iommufd_pt(device, &mut attach_data)?;
 
@@ -2111,6 +2112,7 @@ impl Drop for VfioDevice {
             let detach_data = vfio_device_detach_iommufd_pt {
                 argsz: mem::size_of::<vfio_device_detach_iommufd_pt>() as u32,
                 flags: 0,
+                pasid: 0,
             };
             vfio_syscall::detach_device_iommufd_pt(&self.device, &detach_data).unwrap();
 

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1439,6 +1439,42 @@ impl VfioDevice {
         })
     }
 
+    #[cfg(feature = "vfio_cdev")]
+    /// Attach a PASID of the vfio device to the given page table. The
+    /// kernel requires the page table attached to the device itself to be
+    /// PASID compatible, meaning it was allocated with IOMMU_HWPT_ALLOC_PASID.
+    ///
+    /// # Parameters
+    /// * `pt_id`: the IOAS or HWPT to attach the PASID to.
+    /// * `pasid`: the PASID of the vfio device to attach.
+    pub fn attach_iommufd_pt_pasid(&self, pt_id: u32, pasid: u32) -> Result<()> {
+        let mut attach_data = vfio_device_attach_iommufd_pt {
+            argsz: mem::size_of::<vfio_device_attach_iommufd_pt>() as u32,
+            flags: VFIO_DEVICE_ATTACH_PASID,
+            pt_id,
+            pasid,
+        };
+        vfio_syscall::attach_device_iommufd_pt(&self.device, &mut attach_data)?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "vfio_cdev")]
+    /// Detach a PASID of the vfio device from its current page table.
+    ///
+    /// # Parameters
+    /// * `pasid`: the PASID of the vfio device to detach.
+    pub fn detach_iommufd_pt_pasid(&self, pasid: u32) -> Result<()> {
+        let detach_data = vfio_device_detach_iommufd_pt {
+            argsz: mem::size_of::<vfio_device_detach_iommufd_pt>() as u32,
+            flags: VFIO_DEVICE_DETACH_PASID,
+            pasid,
+        };
+        vfio_syscall::detach_device_iommufd_pt(&self.device, &detach_data)?;
+
+        Ok(())
+    }
+
     /// VFIO device reset only if the device supports being reset.
     pub fn reset(&self) {
         if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 {
@@ -2785,5 +2821,14 @@ mod tests {
             VfioDevice::new_from_bound_fd(device, container),
             Err(VfioError::DowncastVfioOps)
         ));
+    }
+
+    #[cfg(feature = "vfio_cdev")]
+    #[test]
+    fn test_attach_detach_iommufd_pt_pasid() {
+        let device = create_vfio_device();
+
+        device.attach_iommufd_pt_pasid(1, 2).unwrap();
+        device.detach_iommufd_pt_pasid(2).unwrap();
     }
 }


### PR DESCRIPTION
### Summary of the PR
Linux v6.15 commit ad744ed5dd8b extended `VFIO_DEVICE_ATTACH_IOMMUFD_PT` and `VFIO_DEVICE_DETACH_IOMMUFD_PT` with a pasid field and the `VFIO_DEVICE_ATTACH_PASID` and `VFIO_DEVICE_DETACH_PASID` flags, letting userspace attach an individual PASID of a cdev device to an IOAS or HWPT. This series extends the bindings to the new struct layouts and adds the matching verbs to VfioDevice. 

The vfio-bindings change grows two structs, so the next vfio-bindings release needs a semver breaking bump. The CHANGELOG entry is under Changed for that reason.

The bindings edit is hand written but byte identical to bindgen output from v6.15 headers.

Existing callers now pass the larger struct size with the PASID flag clear. Older kernels accept this because argsz is only checked against the minimum size, so behavior is unchanged on kernels before v6.15.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
