### PR TITLE
vfio-ioctls: Add PCI hot reset verbs

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 59.96,
+  "coverage_score": 61.48,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/vfio-ioctls/CHANGELOG.md
+++ b/vfio-ioctls/CHANGELOG.md
@@ -7,6 +7,8 @@
 - [[167]](https://github.com/rust-vmm/vfio/pull/167) Add `attach_iommufd_pt_pasid` and `detach_iommufd_pt_pasid` to
   `VfioDevice` for the PASID variants of the iommufd attach and detach
   ioctls
+- [[170]](https://github.com/rust-vmm/vfio/pull/170) Add `pci_hot_reset_info` and `pci_hot_reset_own_group` to
+  `VfioDevice` for the VFIO PCI hot reset ioctls
 
 ## Fixed
 

--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -68,8 +68,8 @@ mod vfio_device;
 mod vfio_ioctls;
 
 pub use vfio_device::{
-    DmaLoggingRange, PrecopyInfo, VfioContainer, VfioDevice, VfioDeviceFd, VfioGroup, VfioIrq,
-    VfioOps, VfioRegion, VfioRegionInfoCap, VfioRegionInfoCapNvlink2Lnkspd,
+    DmaLoggingRange, PciHotResetDevice, PrecopyInfo, VfioContainer, VfioDevice, VfioDeviceFd,
+    VfioGroup, VfioIrq, VfioOps, VfioRegion, VfioRegionInfoCap, VfioRegionInfoCapNvlink2Lnkspd,
     VfioRegionInfoCapNvlink2Ssatgt, VfioRegionInfoCapSparseMmap, VfioRegionInfoCapType,
     VfioRegionSparseMmapArea,
 };
@@ -105,6 +105,14 @@ pub enum VfioError {
     ContainerSetIOMMU(#[source] SysError),
     #[error("failed to get vfio device fd: {0}")]
     GroupGetDeviceFD(#[source] SysError),
+    #[error("failed to get PCI hot reset information: {0}")]
+    PciHotResetInfo(#[source] SysError),
+    #[error("failed to perform PCI hot reset: {0}")]
+    PciHotReset(#[source] SysError),
+    #[error("PCI hot reset information changed while it was being queried")]
+    PciHotResetInfoChanged,
+    #[error("PCI hot reset through group fds requires the VFIO container/group API")]
+    PciHotResetRequiresContainer,
     #[error("failed to set vfio device's attribute: {0}")]
     SetDeviceAttr(#[source] SysError),
     #[error("failed to get vfio device's info: {0}")]

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1229,6 +1229,19 @@ pub struct DmaLoggingRange {
     pub length: u64,
 }
 
+/// A PCI device affected by a VFIO PCI hot reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PciHotResetDevice {
+    /// VFIO group that owns the device.
+    pub group_id: u32,
+    /// PCI segment number.
+    pub segment: u16,
+    /// PCI bus number.
+    pub bus: u8,
+    /// PCI device and function encoded as in the PCI `devfn` field.
+    pub devfn: u8,
+}
+
 impl VfioDevice {
     #[cfg(not(test))]
     fn get_group_id_from_path(sysfspath: &Path) -> Result<u32> {
@@ -1480,6 +1493,89 @@ impl VfioDevice {
         if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 {
             vfio_syscall::reset(self);
         }
+    }
+
+    /// Return all PCI devices affected by a hot reset of this device.
+    ///
+    /// This operation uses group IDs and is available only to devices opened
+    /// through the legacy VFIO container/group API.
+    pub fn pci_hot_reset_info(&self) -> Result<Vec<PciHotResetDevice>> {
+        if self
+            .vfio_ops
+            .as_any()
+            .downcast_ref::<VfioContainer>()
+            .is_none()
+        {
+            return Err(VfioError::PciHotResetRequiresContainer);
+        }
+        let mut probe = vfio_pci_hot_reset_info {
+            argsz: mem::size_of::<vfio_pci_hot_reset_info>() as u32,
+            ..Default::default()
+        };
+        vfio_syscall::get_pci_hot_reset_info(&self.device, &mut probe, true)?;
+
+        let count = probe.count as usize;
+        let mut buffer =
+            vec_with_array_field::<vfio_pci_hot_reset_info, vfio_pci_dependent_device>(count);
+        let info = &mut buffer[0];
+        info.argsz = (mem::size_of::<vfio_pci_hot_reset_info>()
+            + count * mem::size_of::<vfio_pci_dependent_device>()) as u32;
+        vfio_syscall::get_pci_hot_reset_info(&self.device, info, false)?;
+        if info.count as usize > count {
+            return Err(VfioError::PciHotResetInfoChanged);
+        }
+        // The kernel reports either a group ID or a cdev-only device ID in the
+        // same union, and flags say which. Container-opened devices always get
+        // group IDs, but assert it rather than rely on that invariant: reading
+        // the wrong union member would silently yield meaningless group IDs.
+        if info.flags & VFIO_PCI_HOT_RESET_FLAG_DEV_ID != 0 {
+            return Err(VfioError::PciHotResetRequiresContainer);
+        }
+
+        // SAFETY: `buffer` reserves room for `count` trailing entries and the
+        // kernel reported no more than that many entries.
+        let devices = unsafe { info.devices.as_slice(info.count as usize) };
+        Ok(devices
+            .iter()
+            .map(|device| PciHotResetDevice {
+                // SAFETY: the flags checked above confirm that the union holds
+                // `group_id` rather than the cdev-only `devid` variant.
+                group_id: unsafe { device.__bindgen_anon_1.group_id },
+                segment: device.segment,
+                bus: device.bus,
+                devfn: device.devfn,
+            })
+            .collect())
+    }
+
+    /// Perform a PCI hot reset using this device's group as proof of ownership.
+    ///
+    /// This operation is available only to devices opened through the legacy
+    /// VFIO container/group API. Callers must use [`Self::pci_hot_reset_info`]
+    /// first and ensure that every affected device belongs to this device's
+    /// group.
+    pub fn pci_hot_reset_own_group(&self) -> Result<()> {
+        let container = self
+            .vfio_ops
+            .as_any()
+            .downcast_ref::<VfioContainer>()
+            .ok_or(VfioError::PciHotResetRequiresContainer)?;
+        let sysfspath = self
+            .sysfspath
+            .as_deref()
+            .ok_or(VfioError::PciHotResetRequiresContainer)?;
+        let group_id = Self::get_group_id_from_path(sysfspath)?;
+        let group = container.get_group(group_id)?;
+
+        let mut buffer = vec_with_array_field::<vfio_pci_hot_reset, i32>(1);
+        let reset = &mut buffer[0];
+        reset.argsz = (mem::size_of::<vfio_pci_hot_reset>() + mem::size_of::<i32>()) as u32;
+        reset.count = 1;
+
+        // SAFETY: `buffer` reserves room for one trailing group fd.
+        let group_fds = unsafe { reset.group_fds.as_mut_slice(1) };
+        group_fds[0] = group.as_raw_fd();
+        vfio_syscall::pci_hot_reset(&self.device, reset)
     }
 
     /// Get information about VFIO IRQs.
@@ -2292,6 +2388,35 @@ mod tests {
             migration_data_fd: Mutex::new(None),
             dma_logging_started: Mutex::new(false),
         }
+    }
+
+    #[test]
+    fn test_pci_hot_reset_info() {
+        let device = create_vfio_device();
+        let affected = device.pci_hot_reset_info().unwrap();
+        assert_eq!(
+            affected,
+            vec![
+                PciHotResetDevice {
+                    group_id: 3,
+                    segment: 0,
+                    bus: 0x0f,
+                    devfn: 1,
+                },
+                PciHotResetDevice {
+                    group_id: 4,
+                    segment: 0,
+                    bus: 0x10,
+                    devfn: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_pci_hot_reset() {
+        let device = create_vfio_device();
+        device.pci_hot_reset_own_group().unwrap();
     }
 
     #[test]

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -159,6 +159,37 @@ pub(crate) mod vfio_syscall {
         }
     }
 
+    pub(crate) fn get_pci_hot_reset_info(
+        device: &File,
+        info: &mut vfio_pci_hot_reset_info,
+        allow_enospc: bool,
+    ) -> Result<()> {
+        // SAFETY: `info.argsz` describes the caller-owned buffer and the ioctl
+        // number is defined by the VFIO UAPI.
+        let ret = unsafe { ioctl_with_mut_ref(device, VFIO_DEVICE_GET_PCI_HOT_RESET_INFO(), info) };
+        if ret < 0 {
+            let error = SysError::last();
+            if allow_enospc && error.errno() == libc::ENOSPC {
+                Ok(())
+            } else {
+                Err(VfioError::PciHotResetInfo(error))
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn pci_hot_reset(device: &File, reset: &vfio_pci_hot_reset) -> Result<()> {
+        // SAFETY: `reset.argsz` describes the caller-owned buffer and every fd
+        // in the trailing array comes from a live `VfioGroup`.
+        let ret = unsafe { ioctl_with_ref(device, VFIO_DEVICE_PCI_HOT_RESET(), reset) };
+        if ret < 0 {
+            Err(VfioError::PciHotReset(SysError::last()))
+        } else {
+            Ok(())
+        }
+    }
+
     pub(crate) fn set_group_container(group: &VfioGroup, container: &VfioContainer) -> Result<()> {
         let container_raw_fd = container.as_raw_fd();
         // SAFETY: we are the owner of group and container_raw_fd which are valid value,
@@ -414,6 +445,38 @@ pub(crate) mod vfio_syscall {
         let device = File::open(tmp_file.as_path()).unwrap();
 
         Ok(device)
+    }
+
+    pub(crate) fn get_pci_hot_reset_info(
+        _device: &File,
+        info: &mut vfio_pci_hot_reset_info,
+        probing: bool,
+    ) -> Result<()> {
+        if probing {
+            info.count = 2;
+            return Ok(());
+        }
+
+        info.count = 2;
+        // SAFETY: unit-test callers allocate two trailing entries.
+        let devices = unsafe { info.devices.as_mut_slice(2) };
+        devices[0].__bindgen_anon_1.group_id = 3;
+        devices[0].segment = 0;
+        devices[0].bus = 0x0f;
+        devices[0].devfn = 1;
+        devices[1].__bindgen_anon_1.group_id = 4;
+        devices[1].segment = 0;
+        devices[1].bus = 0x10;
+        devices[1].devfn = 0;
+        Ok(())
+    }
+
+    pub(crate) fn pci_hot_reset(_device: &File, reset: &vfio_pci_hot_reset) -> Result<()> {
+        if reset.count == 0 {
+            Err(VfioError::PciHotReset(SysError::new(libc::EINVAL)))
+        } else {
+            Ok(())
+        }
     }
 
     pub(crate) fn set_group_container(group: &VfioGroup, container: &VfioContainer) -> Result<()> {


### PR DESCRIPTION
### Summary of the PR

`VFIO_DEVICE_PCI_HOT_RESET` issues a PCIe bus reset to a device and everything
sharing its reset domain. The kernel authorizes it by ownership rather than
privilege: the caller must hand over an fd for every VFIO group the reset would
affect. That makes it usable by an unprivileged VMM to clear device state that
the attach-time FLR does not reach — in our case stale GPU firmware session
state left behind when a VM is killed during device initialization.

The ioctl numbers and the UAPI structs are already in `vfio-bindings`, but no
safe wrapper exposed them.

This adds two verbs to `VfioDevice`:

- `pci_hot_reset_info()` — returns the devices a reset would affect as
  `PciHotResetDevice { group_id, segment, bus, devfn }`, using the usual
  two-call size negotiation.
- `pci_hot_reset_own_group()` — performs the reset, passing the device's own
  group fd as the ownership proof.

Both are restricted to container/group-opened devices and return
`PciHotResetRequiresContainer` otherwise: on the cdev path the kernel reports
device IDs in place of group IDs in the same union, and expects a different
ownership proof. `pci_hot_reset_info()` asserts this by checking
`VFIO_PCI_HOT_RESET_FLAG_DEV_ID` in the returned flags rather than relying on
the invariant, since decoding the wrong union member would silently yield
meaningless group IDs.

### Testing

Unit tests through the existing mock-syscall harness, plus real hardware: an
NVIDIA H200 passed through to a TDX guest, alone in its IOMMU group behind a
dedicated PCIe bridge. The reset succeeds as an unprivileged user, the affected
set reported by `pci_hot_reset_info()` contains only the GPU itself, and QEMU
attaches the device successfully immediately afterwards.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
